### PR TITLE
Include support for 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.github.stefvanschie.inventoryframework</groupId>
     <artifactId>IF</artifactId>
-    <version>0.5.3</version>
+    <version>0.5.4</version>
     <packaging>jar</packaging>
 
     <name>IF</name>
@@ -37,11 +37,28 @@
         </developer>
     </developers>
 
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>mojang-repo</id>
+            <url>https://libraries.minecraft.net/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>1.14-pre5-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mojang</groupId>
+            <artifactId>authlib</artifactId>
+            <version>1.5.21</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/github/stefvanschie/inventoryframework/Gui.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/Gui.java
@@ -447,6 +447,18 @@ public class Gui implements Listener, InventoryHolder {
         return inventory;
     }
 
+    //Code taken from InventoryView#getInventory(rawSlot) to support for 1.12 where method doesn't exist
+    public static Inventory getInventory(InventoryView view, int rawSlot) {
+        if(rawSlot == InventoryView.OUTSIDE || rawSlot == -1) {
+            return null;
+        }
+        if(rawSlot < view.getTopInventory().getSize()) {
+            return view.getTopInventory();
+        } else {
+            return view.getBottomInventory();
+        }
+    }
+
     /**
      * Registers a property that can be used inside an XML file to add additional new properties.
      *
@@ -532,18 +544,6 @@ public class Gui implements Listener, InventoryHolder {
         for (int i = panes.size() - 1; i >= 0; i--) {
             if (panes.get(i).click(this, event, 0, 0, 9, getRows() + 4))
                 break;
-        }
-    }
-
-    //Code taken from InventoryView#getInventory(rawSlot) to support for 1.12 where method doesn't exist
-    private Inventory getInventory(InventoryView view, int rawSlot) {
-        if(rawSlot == InventoryView.OUTSIDE || rawSlot == -1) {
-            return null;
-        }
-        if(rawSlot < view.getTopInventory().getSize()) {
-            return view.getTopInventory();
-        } else {
-            return view.getBottomInventory();
         }
     }
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/Gui.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/Gui.java
@@ -14,6 +14,7 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -506,7 +507,7 @@ public class Gui implements Listener, InventoryHolder {
             onGlobalClick.accept(event);
         }
 
-        Inventory inventory = event.getView().getInventory(event.getRawSlot());
+        Inventory inventory = getInventory(event.getView(), event.getRawSlot());
 
         if (inventory == null) {
             return;
@@ -531,6 +532,18 @@ public class Gui implements Listener, InventoryHolder {
         for (int i = panes.size() - 1; i >= 0; i--) {
             if (panes.get(i).click(this, event, 0, 0, 9, getRows() + 4))
                 break;
+        }
+    }
+
+    //Code taken from InventoryView#getInventory(rawSlot) to support for 1.12 where method doesn't exist
+    private Inventory getInventory(InventoryView view, int rawSlot) {
+        if(rawSlot == InventoryView.OUTSIDE || rawSlot == -1) {
+            return null;
+        }
+        if(rawSlot < view.getTopInventory().getSize()) {
+            return view.getTopInventory();
+        } else {
+            return view.getBottomInventory();
         }
     }
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/MasonryPane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/MasonryPane.java
@@ -174,7 +174,7 @@ public class MasonryPane extends Pane implements Orientable {
 
         int x, y;
 
-        if (event.getView().getInventory(event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/MasonryPane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/MasonryPane.java
@@ -174,7 +174,7 @@ public class MasonryPane extends Pane implements Orientable {
 
         int x, y;
 
-        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (Gui.getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
@@ -162,7 +162,7 @@ public class OutlinePane extends Pane implements Flippable, Orientable, Rotatabl
 
         int x, y;
 
-        if (event.getView().getInventory(event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
@@ -162,7 +162,7 @@ public class OutlinePane extends Pane implements Flippable, Orientable, Rotatabl
 
         int x, y;
 
-        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (Gui.getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/PaginatedPane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/PaginatedPane.java
@@ -183,7 +183,7 @@ public class PaginatedPane extends Pane {
 
         int x, y;
 
-        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (Gui.getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/PaginatedPane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/PaginatedPane.java
@@ -183,7 +183,7 @@ public class PaginatedPane extends Pane {
 
         int x, y;
 
-        if (event.getView().getInventory(event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
@@ -16,6 +16,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -498,6 +499,18 @@ public abstract class Pane {
                     throw new XMLLoadException(exception);
                 }
             }
+        }
+    }
+
+    //Code taken from InventoryView#getInventory(rawSlot) to support for 1.12 where method doesn't exist
+    public Inventory getInventory(InventoryView view, int rawSlot) {
+        if(rawSlot == InventoryView.OUTSIDE || rawSlot == -1) {
+            return null;
+        }
+        if(rawSlot < view.getTopInventory().getSize()) {
+            return view.getTopInventory();
+        } else {
+            return view.getBottomInventory();
         }
     }
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
@@ -502,18 +502,6 @@ public abstract class Pane {
         }
     }
 
-    //Code taken from InventoryView#getInventory(rawSlot) to support for 1.12 where method doesn't exist
-    public Inventory getInventory(InventoryView view, int rawSlot) {
-        if(rawSlot == InventoryView.OUTSIDE || rawSlot == -1) {
-            return null;
-        }
-        if(rawSlot < view.getTopInventory().getSize()) {
-            return view.getTopInventory();
-        } else {
-            return view.getBottomInventory();
-        }
-    }
-
     /**
      * Returns the priority of the pane
      *

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/StaticPane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/StaticPane.java
@@ -135,7 +135,7 @@ public class StaticPane extends Pane implements Flippable, Rotatable {
 
 		int x, y;
 
-        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (Gui.getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/StaticPane.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/StaticPane.java
@@ -135,7 +135,7 @@ public class StaticPane extends Pane implements Flippable, Rotatable {
 
 		int x, y;
 
-        if (event.getView().getInventory(event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/CycleButton.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/CycleButton.java
@@ -67,7 +67,7 @@ public class CycleButton extends Pane {
 
         int x, y;
 
-        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (Gui.getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/CycleButton.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/CycleButton.java
@@ -67,7 +67,7 @@ public class CycleButton extends Pane {
 
         int x, y;
 
-        if (event.getView().getInventory(event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PercentageBar.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PercentageBar.java
@@ -52,7 +52,7 @@ public class PercentageBar extends VariableBar {
 
         int x, y;
 
-        if (event.getView().getInventory(event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PercentageBar.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PercentageBar.java
@@ -52,7 +52,7 @@ public class PercentageBar extends VariableBar {
 
         int x, y;
 
-        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (Gui.getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/Slider.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/Slider.java
@@ -52,7 +52,7 @@ public class Slider extends VariableBar {
 
         int x, y;
 
-        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (Gui.getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/Slider.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/Slider.java
@@ -52,7 +52,7 @@ public class Slider extends VariableBar {
 
         int x, y;
 
-        if (event.getView().getInventory(event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/ToggleButton.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/ToggleButton.java
@@ -101,7 +101,7 @@ public class ToggleButton extends Pane {
 
         int x, y;
 
-        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (Gui.getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 

--- a/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/ToggleButton.java
+++ b/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/ToggleButton.java
@@ -101,7 +101,7 @@ public class ToggleButton extends Pane {
 
         int x, y;
 
-        if (event.getView().getInventory(event.getRawSlot()).equals(event.getView().getBottomInventory())) {
+        if (getInventory(event.getView(), event.getRawSlot()).equals(event.getView().getBottomInventory())) {
             x = (slot % 9) - getX() - paneOffsetX;
             y = ((slot / 9) + gui.getRows() - 1) - getY() - paneOffsetY;
 


### PR DESCRIPTION
InventoryView#getInventory(int) method doesn't exist in 1.12 and I didn't want to use older version just only to support it so I used above method's code in the framework to include support for 1.12.

I have also added repositories for Spigot API and Mojang's authlib, because I got errors that dependencies couldn't be found.

Hope it won't be closed as 1.12 has still major usage and it's not a big change to the code.