### PR TITLE
Shaded MiniNBT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                    <relocations>
+                        <relocation>
+                            <pattern>me.ialistannen.mininbt</pattern>
+                            <shadedPattern>com.github.stefvanschie.inventoryframework.shade.mininbt</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Shaded MiniNBT library into `com.github.stefvanschie.inventoryframework.shade.mininbt` to fix `java.lang.NoClassDefFoundError: me/ialistannen/mininbt/NBTWrappers$NBTTagCompound`.