### PR TITLE
Add Adventure support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,4 +2,6 @@ root = true
 
 # Indentation override for all java files
 [**.java]
+indent_style = space
 indent_size = 4
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,10 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 ij_continuation_indent_size = 8
+
+# Indentation override for all
+[pom.xml]
+indent_style = space
+indent_size = 4
+insert_final_newline = false
+ij_continuation_indent_size = 8

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,4 @@ root = true
 indent_style = space
 indent_size = 4
 insert_final_newline = true
+ij_continuation_indent_size = 8

--- a/IF/pom.xml
+++ b/IF/pom.xml
@@ -29,6 +29,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>${adventure.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.stefvanschie.inventoryframework</groupId>
             <artifactId>abstraction</artifactId>
             <version>${project.version}</version>

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/AnvilGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/AnvilGui.java
@@ -1,12 +1,12 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -74,8 +74,8 @@ public class AnvilGui extends NamedGui {
     public AnvilGui(@NotNull String title) {
         super(title);
     }
-    
-    public AnvilGui(@NotNull Component title) {
+
+    public AnvilGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/AnvilGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/AnvilGui.java
@@ -6,7 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -72,6 +72,10 @@ public class AnvilGui extends NamedGui {
      * @since 0.8.0
      */
     public AnvilGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public AnvilGui(@NotNull Component title) {
         super(title);
     }
 
@@ -140,8 +144,8 @@ public class AnvilGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.ANVIL, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.ANVIL);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/AnvilGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/AnvilGui.java
@@ -79,7 +79,7 @@ public class AnvilGui extends NamedGui {
      * Constructs a new anvil gui
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public AnvilGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/AnvilGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/AnvilGui.java
@@ -75,6 +75,12 @@ public class AnvilGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new anvil gui
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public AnvilGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BarrelGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BarrelGui.java
@@ -6,7 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.MergedGui;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -48,6 +48,10 @@ public class BarrelGui extends NamedGui implements MergedGui {
      * @since 0.8.0
      */
     public BarrelGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public BarrelGui(@NotNull Component title) {
         super(title);
     }
 
@@ -128,8 +132,8 @@ public class BarrelGui extends NamedGui implements MergedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.BARREL, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.BARREL);
     }
 
     @NotNull

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BarrelGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BarrelGui.java
@@ -51,6 +51,12 @@ public class BarrelGui extends NamedGui implements MergedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public BarrelGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BarrelGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BarrelGui.java
@@ -55,7 +55,7 @@ public class BarrelGui extends NamedGui implements MergedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public BarrelGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BarrelGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BarrelGui.java
@@ -1,12 +1,12 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.GuiItem;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.MergedGui;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -50,8 +50,8 @@ public class BarrelGui extends NamedGui implements MergedGui {
     public BarrelGui(@NotNull String title) {
         super(title);
     }
-    
-    public BarrelGui(@NotNull Component title) {
+
+    public BarrelGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BeaconGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BeaconGui.java
@@ -114,7 +114,7 @@ public class BeaconGui extends Gui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory() {
+    protected Inventory createInventory() {
         return Bukkit.createInventory(this, InventoryType.BEACON);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BlastFurnaceGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BlastFurnaceGui.java
@@ -1,9 +1,9 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -62,8 +62,8 @@ public class BlastFurnaceGui extends NamedGui {
     public BlastFurnaceGui(@NotNull String title) {
         super(title);
     }
-    
-    public BlastFurnaceGui(@NotNull Component title) {
+
+    public BlastFurnaceGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BlastFurnaceGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BlastFurnaceGui.java
@@ -67,7 +67,7 @@ public class BlastFurnaceGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public BlastFurnaceGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BlastFurnaceGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BlastFurnaceGui.java
@@ -3,7 +3,7 @@ package com.github.stefvanschie.inventoryframework.gui.type;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -60,6 +60,10 @@ public class BlastFurnaceGui extends NamedGui {
      * @since 0.8.0
      */
     public BlastFurnaceGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public BlastFurnaceGui(@NotNull Component title) {
         super(title);
     }
 
@@ -129,8 +133,8 @@ public class BlastFurnaceGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.BLAST_FURNACE, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.BLAST_FURNACE);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BlastFurnaceGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BlastFurnaceGui.java
@@ -63,6 +63,12 @@ public class BlastFurnaceGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public BlastFurnaceGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BrewingStandGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BrewingStandGui.java
@@ -75,6 +75,12 @@ public class BrewingStandGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public BrewingStandGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BrewingStandGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BrewingStandGui.java
@@ -1,9 +1,9 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -74,8 +74,8 @@ public class BrewingStandGui extends NamedGui {
     public BrewingStandGui(@NotNull String title) {
         super(title);
     }
-    
-    public BrewingStandGui(@NotNull Component title) {
+
+    public BrewingStandGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BrewingStandGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BrewingStandGui.java
@@ -3,7 +3,7 @@ package com.github.stefvanschie.inventoryframework.gui.type;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -72,6 +72,10 @@ public class BrewingStandGui extends NamedGui {
      * @since 0.8.0
      */
     public BrewingStandGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public BrewingStandGui(@NotNull Component title) {
         super(title);
     }
 
@@ -149,8 +153,8 @@ public class BrewingStandGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        Inventory inventory = Bukkit.createInventory(this, InventoryType.BREWING, title);
+    protected Inventory createInventory() {
+        Inventory inventory = getTitleHolder().asInventoryTitle(this, InventoryType.BREWING);
 
         addInventory(inventory, this);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BrewingStandGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/BrewingStandGui.java
@@ -79,7 +79,7 @@ public class BrewingStandGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public BrewingStandGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CartographyTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CartographyTableGui.java
@@ -82,7 +82,7 @@ public class CartographyTableGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public CartographyTableGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CartographyTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CartographyTableGui.java
@@ -1,12 +1,12 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -77,8 +77,8 @@ public class CartographyTableGui extends NamedGui {
     public CartographyTableGui(@NotNull String title) {
         super(title);
     }
-    
-    public CartographyTableGui(@NotNull Component title) {
+
+    public CartographyTableGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CartographyTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CartographyTableGui.java
@@ -78,6 +78,12 @@ public class CartographyTableGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public CartographyTableGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CartographyTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CartographyTableGui.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -74,6 +75,10 @@ public class CartographyTableGui extends NamedGui {
      * @since 0.8.0
      */
     public CartographyTableGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public CartographyTableGui(@NotNull Component title) {
         super(title);
     }
 
@@ -147,8 +152,8 @@ public class CartographyTableGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.CARTOGRAPHY, title);
+    protected Inventory createInventory() {
+		return getTitleHolder().asInventoryTitle(this, InventoryType.CARTOGRAPHY);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
@@ -43,11 +43,6 @@ public class ChestGui extends NamedGui implements MergedGui {
     private InventoryComponent inventoryComponent;
 
     /**
-     * The amount of rows this gui has
-     */
-    private int rows;
-
-    /**
      * Constructs a new chest GUI
      *
      * @param rows the amount of rows this gui should contain, in range 1..6.
@@ -57,7 +52,14 @@ public class ChestGui extends NamedGui implements MergedGui {
     public ChestGui(int rows, @NotNull String title) {
         this(rows, StringHolder.of(title));
     }
-    
+
+    /**
+     * Constructs a new chest GUI
+     *
+     * @param rows the amount of rows this gui should contain, in range 1..6.
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public ChestGui(int rows, @NotNull TextHolder title) {
         super(title);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
@@ -58,7 +58,7 @@ public class ChestGui extends NamedGui implements MergedGui {
      *
      * @param rows the amount of rows this gui should contain, in range 1..6.
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public ChestGui(int rows, @NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
@@ -1,12 +1,15 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.GuiItem;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.MergedGui;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
@@ -54,6 +57,14 @@ public class ChestGui extends NamedGui implements MergedGui {
      * @since 0.8.0
      */
     public ChestGui(int rows, @NotNull String title) {
+        this(rows, StringHolder.of(title));
+    }
+    
+    public ChestGui(int rows, @NotNull Component title) {
+        this(rows, ComponentHolder.of(title));
+    }
+    
+    public ChestGui(int rows, @NotNull TextHolder title) {
         super(title);
 
         if (!(rows >= 1 && rows <= 6)) {
@@ -135,7 +146,7 @@ public class ChestGui extends NamedGui implements MergedGui {
         //copy the viewers
         List<HumanEntity> viewers = getViewers();
 
-        this.inventory = Bukkit.createInventory(this, rows * 9, getTitle());
+        this.inventory = createInventory();
 
         viewers.forEach(humanEntity -> humanEntity.openInventory(inventory));
     }
@@ -162,8 +173,8 @@ public class ChestGui extends NamedGui implements MergedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, getRows() * 9, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, getRows() * 9);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
@@ -1,6 +1,5 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
-import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
@@ -9,7 +8,6 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.MergedGui;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
@@ -58,10 +56,6 @@ public class ChestGui extends NamedGui implements MergedGui {
      */
     public ChestGui(int rows, @NotNull String title) {
         this(rows, StringHolder.of(title));
-    }
-    
-    public ChestGui(int rows, @NotNull Component title) {
-        this(rows, ComponentHolder.of(title));
     }
     
     public ChestGui(int rows, @NotNull TextHolder title) {

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CraftingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CraftingTableGui.java
@@ -61,7 +61,7 @@ public class CraftingTableGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public CraftingTableGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CraftingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CraftingTableGui.java
@@ -57,6 +57,12 @@ public class CraftingTableGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public CraftingTableGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CraftingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CraftingTableGui.java
@@ -1,9 +1,9 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -56,8 +56,8 @@ public class CraftingTableGui extends NamedGui {
     public CraftingTableGui(@NotNull String title) {
         super(title);
     }
-    
-    public CraftingTableGui(@NotNull Component title) {
+
+    public CraftingTableGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CraftingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/CraftingTableGui.java
@@ -3,7 +3,7 @@ package com.github.stefvanschie.inventoryframework.gui.type;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -54,6 +54,10 @@ public class CraftingTableGui extends NamedGui {
      * @since 0.8.0
      */
     public CraftingTableGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public CraftingTableGui(@NotNull Component title) {
         super(title);
     }
 
@@ -119,8 +123,8 @@ public class CraftingTableGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.WORKBENCH, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.WORKBENCH);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DispenserGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DispenserGui.java
@@ -51,6 +51,12 @@ public class DispenserGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public DispenserGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DispenserGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DispenserGui.java
@@ -3,7 +3,7 @@ package com.github.stefvanschie.inventoryframework.gui.type;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -48,6 +48,10 @@ public class DispenserGui extends NamedGui {
      * @since 0.8.0
      */
     public DispenserGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public DispenserGui(@NotNull Component title) {
         super(title);
     }
 
@@ -109,8 +113,8 @@ public class DispenserGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        Inventory inventory = Bukkit.createInventory(this, InventoryType.DISPENSER, title);
+    protected Inventory createInventory() {
+        Inventory inventory = getTitleHolder().asInventoryTitle(this, InventoryType.DISPENSER);
 
         addInventory(inventory, this);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DispenserGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DispenserGui.java
@@ -55,7 +55,7 @@ public class DispenserGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public DispenserGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DispenserGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DispenserGui.java
@@ -1,9 +1,9 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -50,8 +50,8 @@ public class DispenserGui extends NamedGui {
     public DispenserGui(@NotNull String title) {
         super(title);
     }
-    
-    public DispenserGui(@NotNull Component title) {
+
+    public DispenserGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DropperGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DropperGui.java
@@ -55,7 +55,7 @@ public class DropperGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public DropperGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DropperGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DropperGui.java
@@ -51,6 +51,12 @@ public class DropperGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public DropperGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DropperGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DropperGui.java
@@ -1,9 +1,9 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -50,8 +50,8 @@ public class DropperGui extends NamedGui {
     public DropperGui(@NotNull String title) {
         super(title);
     }
-    
-    public DropperGui(@NotNull Component title) {
+
+    public DropperGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DropperGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/DropperGui.java
@@ -3,7 +3,7 @@ package com.github.stefvanschie.inventoryframework.gui.type;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -48,6 +48,10 @@ public class DropperGui extends NamedGui {
      * @since 0.8.0
      */
     public DropperGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public DropperGui(@NotNull Component title) {
         super(title);
     }
 
@@ -109,8 +113,8 @@ public class DropperGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        Inventory inventory = Bukkit.createInventory(this, InventoryType.DROPPER, title);
+    protected Inventory createInventory() {
+        Inventory inventory = getTitleHolder().asInventoryTitle(this, InventoryType.DROPPER);
 
         addInventory(inventory, this);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnchantingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnchantingTableGui.java
@@ -1,12 +1,12 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -62,8 +62,8 @@ public class EnchantingTableGui extends NamedGui {
     public EnchantingTableGui(@NotNull String title) {
         super(title);
     }
-    
-    public EnchantingTableGui(@NotNull Component title) {
+
+    public EnchantingTableGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnchantingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnchantingTableGui.java
@@ -67,7 +67,7 @@ public class EnchantingTableGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public EnchantingTableGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnchantingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnchantingTableGui.java
@@ -63,6 +63,12 @@ public class EnchantingTableGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public EnchantingTableGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnchantingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnchantingTableGui.java
@@ -6,7 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -60,6 +60,10 @@ public class EnchantingTableGui extends NamedGui {
      * @since 0.8.0
      */
     public EnchantingTableGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public EnchantingTableGui(@NotNull Component title) {
         super(title);
     }
 
@@ -125,8 +129,8 @@ public class EnchantingTableGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.ENCHANTING, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.ENCHANTING);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnderChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnderChestGui.java
@@ -6,7 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.MergedGui;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -48,6 +48,10 @@ public class EnderChestGui extends NamedGui implements MergedGui {
      * @since 0.8.0
      */
     public EnderChestGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public EnderChestGui(@NotNull Component title) {
         super(title);
     }
 
@@ -128,8 +132,8 @@ public class EnderChestGui extends NamedGui implements MergedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.ENDER_CHEST, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.ENDER_CHEST);
     }
 
     @NotNull

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnderChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnderChestGui.java
@@ -55,7 +55,7 @@ public class EnderChestGui extends NamedGui implements MergedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public EnderChestGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnderChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnderChestGui.java
@@ -51,6 +51,12 @@ public class EnderChestGui extends NamedGui implements MergedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public EnderChestGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnderChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/EnderChestGui.java
@@ -1,12 +1,12 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.GuiItem;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.MergedGui;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -50,8 +50,8 @@ public class EnderChestGui extends NamedGui implements MergedGui {
     public EnderChestGui(@NotNull String title) {
         super(title);
     }
-    
-    public EnderChestGui(@NotNull Component title) {
+
+    public EnderChestGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/FurnaceGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/FurnaceGui.java
@@ -1,9 +1,9 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -62,8 +62,8 @@ public class FurnaceGui extends NamedGui {
     public FurnaceGui(@NotNull String title) {
         super(title);
     }
-    
-    public FurnaceGui(@NotNull Component title) {
+
+    public FurnaceGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/FurnaceGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/FurnaceGui.java
@@ -63,6 +63,12 @@ public class FurnaceGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public FurnaceGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/FurnaceGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/FurnaceGui.java
@@ -3,7 +3,7 @@ package com.github.stefvanschie.inventoryframework.gui.type;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -60,6 +60,10 @@ public class FurnaceGui extends NamedGui {
      * @since 0.8.0
      */
     public FurnaceGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public FurnaceGui(@NotNull Component title) {
         super(title);
     }
 
@@ -129,8 +133,8 @@ public class FurnaceGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        Inventory inventory = Bukkit.createInventory(this, InventoryType.FURNACE, title);
+    protected Inventory createInventory() {
+        Inventory inventory = getTitleHolder().asInventoryTitle(this, InventoryType.FURNACE);
 
         addInventory(inventory, this);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/FurnaceGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/FurnaceGui.java
@@ -67,7 +67,7 @@ public class FurnaceGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public FurnaceGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/GrindstoneGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/GrindstoneGui.java
@@ -6,7 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -66,6 +66,10 @@ public class GrindstoneGui extends NamedGui {
      * @since 0.8.0
      */
     public GrindstoneGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public GrindstoneGui(@NotNull Component title) {
         super(title);
     }
 
@@ -135,8 +139,8 @@ public class GrindstoneGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.GRINDSTONE, title);
+    protected Inventory createInventory() {
+		return getTitleHolder().asInventoryTitle(this, InventoryType.GRINDSTONE);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/GrindstoneGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/GrindstoneGui.java
@@ -1,12 +1,12 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -68,8 +68,8 @@ public class GrindstoneGui extends NamedGui {
     public GrindstoneGui(@NotNull String title) {
         super(title);
     }
-    
-    public GrindstoneGui(@NotNull Component title) {
+
+    public GrindstoneGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/GrindstoneGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/GrindstoneGui.java
@@ -73,7 +73,7 @@ public class GrindstoneGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public GrindstoneGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/GrindstoneGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/GrindstoneGui.java
@@ -69,6 +69,12 @@ public class GrindstoneGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public GrindstoneGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/HopperGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/HopperGui.java
@@ -3,7 +3,7 @@ package com.github.stefvanschie.inventoryframework.gui.type;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -48,6 +48,10 @@ public class HopperGui extends NamedGui {
      * @since 0.8.0
      */
     public HopperGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public HopperGui(@NotNull Component title) {
         super(title);
     }
 
@@ -109,8 +113,8 @@ public class HopperGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        Inventory inventory = Bukkit.createInventory(this, InventoryType.HOPPER, title);
+    protected Inventory createInventory() {
+        Inventory inventory = getTitleHolder().asInventoryTitle(this, InventoryType.HOPPER);
 
         addInventory(inventory, this);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/HopperGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/HopperGui.java
@@ -55,7 +55,7 @@ public class HopperGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public HopperGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/HopperGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/HopperGui.java
@@ -1,9 +1,9 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -50,8 +50,8 @@ public class HopperGui extends NamedGui {
     public HopperGui(@NotNull String title) {
         super(title);
     }
-    
-    public HopperGui(@NotNull Component title) {
+
+    public HopperGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/HopperGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/HopperGui.java
@@ -51,6 +51,12 @@ public class HopperGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public HopperGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ShulkerBoxGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ShulkerBoxGui.java
@@ -55,7 +55,7 @@ public class ShulkerBoxGui extends NamedGui implements MergedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public ShulkerBoxGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ShulkerBoxGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ShulkerBoxGui.java
@@ -51,6 +51,12 @@ public class ShulkerBoxGui extends NamedGui implements MergedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public ShulkerBoxGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ShulkerBoxGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ShulkerBoxGui.java
@@ -1,12 +1,12 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.GuiItem;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.MergedGui;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -50,8 +50,8 @@ public class ShulkerBoxGui extends NamedGui implements MergedGui {
     public ShulkerBoxGui(@NotNull String title) {
         super(title);
     }
-    
-    public ShulkerBoxGui(@NotNull Component title) {
+
+    public ShulkerBoxGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ShulkerBoxGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ShulkerBoxGui.java
@@ -6,7 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.MergedGui;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -48,6 +48,10 @@ public class ShulkerBoxGui extends NamedGui implements MergedGui {
      * @since 0.8.0
      */
     public ShulkerBoxGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public ShulkerBoxGui(@NotNull Component title) {
         super(title);
     }
 
@@ -128,8 +132,8 @@ public class ShulkerBoxGui extends NamedGui implements MergedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.SHULKER_BOX, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.SHULKER_BOX);
     }
 
     @NotNull

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmithingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmithingTableGui.java
@@ -76,6 +76,12 @@ public class SmithingTableGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public SmithingTableGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmithingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmithingTableGui.java
@@ -80,7 +80,7 @@ public class SmithingTableGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public SmithingTableGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmithingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmithingTableGui.java
@@ -1,12 +1,12 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
 import com.github.stefvanschie.inventoryframework.abstraction.SmithingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -75,8 +75,8 @@ public class SmithingTableGui extends NamedGui {
     public SmithingTableGui(@NotNull String title) {
         super(title);
     }
-    
-    public SmithingTableGui(@NotNull Component title) {
+
+    public SmithingTableGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmithingTableGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmithingTableGui.java
@@ -6,7 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -73,6 +73,10 @@ public class SmithingTableGui extends NamedGui {
      * @since 0.8.0
      */
     public SmithingTableGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public SmithingTableGui(@NotNull Component title) {
         super(title);
     }
 
@@ -146,8 +150,8 @@ public class SmithingTableGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.SMITHING, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.SMITHING);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmokerGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmokerGui.java
@@ -1,9 +1,9 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -62,8 +62,8 @@ public class SmokerGui extends NamedGui {
     public SmokerGui(@NotNull String title) {
         super(title);
     }
-    
-    public SmokerGui(@NotNull Component title) {
+
+    public SmokerGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmokerGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmokerGui.java
@@ -3,7 +3,7 @@ package com.github.stefvanschie.inventoryframework.gui.type;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -60,6 +60,10 @@ public class SmokerGui extends NamedGui {
      * @since 0.8.0
      */
     public SmokerGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public SmokerGui(@NotNull Component title) {
         super(title);
     }
 
@@ -129,8 +133,8 @@ public class SmokerGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.SMOKER, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.SMOKER);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmokerGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmokerGui.java
@@ -63,6 +63,12 @@ public class SmokerGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public SmokerGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmokerGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/SmokerGui.java
@@ -67,7 +67,7 @@ public class SmokerGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public SmokerGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/StonecutterGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/StonecutterGui.java
@@ -74,7 +74,7 @@ public class StonecutterGui extends NamedGui {
      * Constructs a new GUI
      *
      * @param title the title/name of this gui.
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public StonecutterGui(@NotNull TextHolder title) {
         super(title);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/StonecutterGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/StonecutterGui.java
@@ -70,6 +70,12 @@ public class StonecutterGui extends NamedGui {
         super(title);
     }
 
+    /**
+     * Constructs a new GUI
+     *
+     * @param title the title/name of this gui.
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public StonecutterGui(@NotNull TextHolder title) {
         super(title);
     }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/StonecutterGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/StonecutterGui.java
@@ -6,7 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import org.bukkit.Bukkit;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -67,6 +67,10 @@ public class StonecutterGui extends NamedGui {
      * @since 0.8.0
      */
     public StonecutterGui(@NotNull String title) {
+        super(title);
+    }
+    
+    public StonecutterGui(@NotNull Component title) {
         super(title);
     }
 
@@ -136,8 +140,8 @@ public class StonecutterGui extends NamedGui {
     @NotNull
     @Contract(pure = true)
     @Override
-    public Inventory createInventory(@NotNull String title) {
-        return Bukkit.createInventory(this, InventoryType.STONECUTTER, title);
+    protected Inventory createInventory() {
+        return getTitleHolder().asInventoryTitle(this, InventoryType.STONECUTTER);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/StonecutterGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/StonecutterGui.java
@@ -1,12 +1,12 @@
 package com.github.stefvanschie.inventoryframework.gui.type;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.NamedGui;
 import com.github.stefvanschie.inventoryframework.util.version.Version;
 import com.github.stefvanschie.inventoryframework.util.version.VersionMatcher;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -69,8 +69,8 @@ public class StonecutterGui extends NamedGui {
     public StonecutterGui(@NotNull String title) {
         super(title);
     }
-    
-    public StonecutterGui(@NotNull Component title) {
+
+    public StonecutterGui(@NotNull TextHolder title) {
         super(title);
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/Gui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/Gui.java
@@ -151,14 +151,14 @@ public abstract class Gui implements InventoryHolder {
     }
 
     /**
-     * Creates a new inventory of the type of the implementing class with the provided title.
+     * Creates a new inventory of the type of the implementing class.
      *
      * @return the new inventory
      * @since 0.8.0
      */
     @NotNull
     @Contract(pure = true)
-    public abstract Inventory createInventory();
+    protected abstract Inventory createInventory();
 
     /**
      * Shows a gui to a player

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/NamedGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/NamedGui.java
@@ -26,6 +26,12 @@ public abstract class NamedGui extends Gui {
         this(StringHolder.of(title));
     }
 
+    /**
+     * Constructs a new gui with a title
+     *
+     * @param title the title/name of this gui
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public NamedGui(@NotNull TextHolder title) {
         this.title = title;
     }
@@ -40,6 +46,13 @@ public abstract class NamedGui extends Gui {
         setTitle(StringHolder.of(title));
     }
 
+    /**
+     * Sets the title for this inventory. This will (unlike most other methods) directly update itself in order
+     * to ensure all viewers will still be viewing the new inventory as well.
+     *
+     * @param title the title
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public void setTitle(@NotNull TextHolder title) {
         //copy the viewers
         List<HumanEntity> viewers = getViewers();
@@ -57,7 +70,7 @@ public abstract class NamedGui extends Gui {
     }
 
     /**
-     * Returns the title of this gui
+     * Returns the title of this gui as a legacy string.
      *
      * @return the title
      * @since 0.8.0
@@ -68,6 +81,12 @@ public abstract class NamedGui extends Gui {
         return title.asLegacyString();
     }
 
+    /**
+     * Returns the title of this GUI in a wrapped form.
+     *
+     * @return the title
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public TextHolder getTitleHolder() {

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/NamedGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/NamedGui.java
@@ -1,9 +1,10 @@
 package com.github.stefvanschie.inventoryframework.gui.type.util;
 
-import org.bukkit.Bukkit;
+import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -15,7 +16,7 @@ public abstract class NamedGui extends Gui {
      * The title of this gui
      */
     @NotNull
-    private String title;
+    private TextHolder title;
 
     /**
      * Constructs a new gui with a title
@@ -24,34 +25,15 @@ public abstract class NamedGui extends Gui {
      * @since 0.8.0
      */
     public NamedGui(@NotNull String title) {
+        this(StringHolder.of(title));
+    }
+    
+    public NamedGui(@NotNull Component title) {
+        this(ComponentHolder.of(title));
+    }
+    
+    protected NamedGui(@NotNull TextHolder title) {
         this.title = title;
-    }
-
-    /**
-     * Creates a new inventory of the type of the implementing class with the provided title.
-     *
-     * @param title the title for the new inventory
-     * @return the new inventory
-     * @since 0.8.0
-     */
-    @NotNull
-    @Contract(pure = true)
-    public abstract Inventory createInventory(@NotNull String title);
-
-    @NotNull
-    @Override
-    public Inventory getInventory() {
-        if (this.inventory == null) {
-            this.inventory = createInventory(getTitle());
-        }
-
-        return inventory;
-    }
-
-    @NotNull
-    @Override
-    public Inventory createInventory() {
-        return createInventory(title);
     }
 
     /**
@@ -61,11 +43,19 @@ public abstract class NamedGui extends Gui {
      * @param title the title
      */
     public void setTitle(@NotNull String title) {
+        setTitle(StringHolder.of(title));
+    }
+    
+    public void setTitle(@NotNull Component title) {
+        setTitle(ComponentHolder.of(title));
+    }
+    
+    private void setTitle(@NotNull TextHolder title) {
         //copy the viewers
         List<HumanEntity> viewers = getViewers();
 
-        this.inventory = createInventory(title);
         this.title = title;
+        this.inventory = createInventory();
 
         updating = true;
 
@@ -85,6 +75,18 @@ public abstract class NamedGui extends Gui {
     @NotNull
     @Contract(pure = true)
     public String getTitle() {
+        return title.asLegacyString();
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public Component title() {
+        return title.asComponent();
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    protected TextHolder getTitleHolder() {
         return title;
     }
 }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/NamedGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/NamedGui.java
@@ -1,9 +1,7 @@
 package com.github.stefvanschie.inventoryframework.gui.type.util;
 
-import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import net.kyori.adventure.text.Component;
 import org.bukkit.entity.HumanEntity;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -27,12 +25,8 @@ public abstract class NamedGui extends Gui {
     public NamedGui(@NotNull String title) {
         this(StringHolder.of(title));
     }
-    
-    public NamedGui(@NotNull Component title) {
-        this(ComponentHolder.of(title));
-    }
-    
-    protected NamedGui(@NotNull TextHolder title) {
+
+    public NamedGui(@NotNull TextHolder title) {
         this.title = title;
     }
 
@@ -45,12 +39,8 @@ public abstract class NamedGui extends Gui {
     public void setTitle(@NotNull String title) {
         setTitle(StringHolder.of(title));
     }
-    
-    public void setTitle(@NotNull Component title) {
-        setTitle(ComponentHolder.of(title));
-    }
-    
-    private void setTitle(@NotNull TextHolder title) {
+
+    public void setTitle(@NotNull TextHolder title) {
         //copy the viewers
         List<HumanEntity> viewers = getViewers();
 
@@ -77,16 +67,10 @@ public abstract class NamedGui extends Gui {
     public String getTitle() {
         return title.asLegacyString();
     }
-    
+
     @NotNull
     @Contract(pure = true)
-    public Component title() {
-        return title.asComponent();
-    }
-    
-    @NotNull
-    @Contract(pure = true)
-    protected TextHolder getTitleHolder() {
+    public TextHolder getTitleHolder() {
         return title;
     }
 }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/NamedGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/util/NamedGui.java
@@ -30,7 +30,7 @@ public abstract class NamedGui extends Gui {
      * Constructs a new gui with a title
      *
      * @param title the title/name of this gui
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public NamedGui(@NotNull TextHolder title) {
         this.title = title;
@@ -51,7 +51,7 @@ public abstract class NamedGui extends Gui {
      * to ensure all viewers will still be viewing the new inventory as well.
      *
      * @param title the title
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public void setTitle(@NotNull TextHolder title) {
         //copy the viewers
@@ -85,7 +85,7 @@ public abstract class NamedGui extends Gui {
      * Returns the title of this GUI in a wrapped form.
      *
      * @return the title
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
@@ -358,7 +358,8 @@ public abstract class Pane {
                                 if (!innerNode.getNodeName().equals("line"))
                                     continue;
 
-								TextHolder.fromNodeTextContent(innerNode).asItemLoreAtEnd(itemMeta);
+								TextHolder.deserialize(innerNode.getTextContent())
+                                        .asItemLoreAtEnd(itemMeta);
                                 itemStack.setItemMeta(itemMeta);
                                 break;
                             case "enchantments":
@@ -383,7 +384,8 @@ public abstract class Pane {
                 } else if (nodeName.equals("displayname")) {
                     ItemMeta itemMeta = Objects.requireNonNull(itemStack.getItemMeta());
 
-                    TextHolder.fromNodeTextContent(item).asItemDisplayName(itemMeta);
+                    TextHolder.deserialize(item.getTextContent())
+                            .asItemDisplayName(itemMeta);
 
                     itemStack.setItemMeta(itemMeta);
                 } else if (nodeName.equals("skull") && itemStack.getItemMeta() instanceof SkullMeta) {

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
@@ -358,7 +358,7 @@ public abstract class Pane {
                                 if (!innerNode.getNodeName().equals("line"))
                                     continue;
 
-								TextHolder.deserialize(innerNode.getTextContent())
+                                TextHolder.deserialize(innerNode.getTextContent())
                                         .asItemLoreAtEnd(itemMeta);
                                 itemStack.setItemMeta(itemMeta);
                                 break;

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
@@ -1,5 +1,6 @@
 package com.github.stefvanschie.inventoryframework.pane;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import com.github.stefvanschie.inventoryframework.gui.InventoryComponent;
 import com.github.stefvanschie.inventoryframework.gui.type.util.Gui;
 import com.github.stefvanschie.inventoryframework.gui.GuiItem;
@@ -10,7 +11,6 @@ import com.github.stefvanschie.inventoryframework.util.UUIDTagType;
 import com.github.stefvanschie.inventoryframework.util.XMLUtil;
 import com.google.common.primitives.Primitives;
 import org.apache.commons.lang3.reflect.MethodUtils;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
@@ -358,12 +358,7 @@ public abstract class Pane {
                                 if (!innerNode.getNodeName().equals("line"))
                                     continue;
 
-                                boolean hasLore = itemMeta.hasLore();
-                                List<String> lore = hasLore ? Objects.requireNonNull(itemMeta.getLore()) : new ArrayList<>();
-
-                                lore.add(ChatColor.translateAlternateColorCodes('&', innerNode
-                                        .getTextContent()));
-                                itemMeta.setLore(lore);
+								TextHolder.fromNodeTextContent(innerNode).asItemLoreAtEnd(itemMeta);
                                 itemStack.setItemMeta(itemMeta);
                                 break;
                             case "enchantments":
@@ -388,8 +383,7 @@ public abstract class Pane {
                 } else if (nodeName.equals("displayname")) {
                     ItemMeta itemMeta = Objects.requireNonNull(itemStack.getItemMeta());
 
-                    itemMeta.setDisplayName(ChatColor.translateAlternateColorCodes('&', item
-                            .getTextContent()));
+                    TextHolder.fromNodeTextContent(item).asItemDisplayName(itemMeta);
 
                     itemStack.setItemMeta(itemMeta);
                 } else if (nodeName.equals("skull") && itemStack.getItemMeta() instanceof SkullMeta) {

--- a/README.md
+++ b/README.md
@@ -90,10 +90,39 @@ The build can then be found in /IF/target/.
 
 ## Adventure support
 
-TODO actually write this part of the readme
+IF supports [Adventure](https://github.com/KyoriPowered/adventure), but does not shade it in itself.
+The use of Adventure `Component`s instead of legacy `String`s completely optional.
+If you do not wish to use Adventure you can safely ignore all `TextHolder` related methods.
 
-https://docs.adventure.kyori.net/platform/index.html
+### What is Adventure?
 
-full support is obviously only achieved when your platform
-(spigot/Paper) natively supports adventure...
-but adventure also works on spigot: stuff get converted to legacy
+Adventure is a library that adds proper modern text support to Minecraft.
+Modern text is represented using bungee-chat and `BaseComponent` instances in Spigot.
+Adventure is an alternative to bungee-chat and offers more features.
+
+### Using Adventure on 1.16.5+ Paper
+
+You don't need to import/shade anything for Adventure support in this case!
+
+*Note: Paper only supports Adventure on build 473 and above. If you aren't running months old builds, then you are fine.*
+
+### Using Adventure on Spigot and older Paper
+
+On Spigot Adventure isn't included in the server, therefore you have to shade and relocate it yourself.
+The following dependencies need to be imported and shaded:
+- adventure-api
+- adventure-platform-bukkit
+
+Please consult the [Adventure documentation](https://docs.adventure.kyori.net/) for more information.
+
+### How to use Adventure `Component`s
+
+Example of migration from legacy `String` to Adventure `Component`:
+ - legacy: `namedGui.setTitle("My Title!");`
+ - Adventure: `namedGui.setTitle(ComponentHolder.of(Component.text("My Title!")));`
+
+We apologize for the boilerplate (the `ComponentHolder.of(...)` call), but that was the only way to not make IF hard-depend on Adventure.
+
+Full Adventure support is only achieved when your server natively supports Adventure.
+In other words, you won't benefit from Adventure as much if you use Spigot instead of Paper.
+This is because for Spigot we have to convert everything back to legacy `String`s before passing them to the Bukkit API.

--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ If you want to build this project from source, run the following from Git Bash:
 
 The build can then be found in /IF/target/.
 
-TODO adventure support notes
-- proper adventure support is only achieved if you run paper:
-    we can only create adventure inventory titles on paper
-  
-TODO actual TODO for me:
- - which adventure versions to use? same one in all places?
-    even in 1.14 NMS?
+## Adventure support
+
+TODO actually write this part of the readme
+
+https://docs.adventure.kyori.net/platform/index.html
+
+full support is obviously only achieved when your platform
+(spigot/Paper) natively supports adventure...
+but adventure also works on spigot: stuff get converted to legacy

--- a/README.md
+++ b/README.md
@@ -87,3 +87,11 @@ If you want to build this project from source, run the following from Git Bash:
     mvn clean package
 
 The build can then be found in /IF/target/.
+
+TODO adventure support notes
+- proper adventure support is only achieved if you run paper:
+    we can only create adventure inventory titles on paper
+  
+TODO actual TODO for me:
+ - which adventure versions to use? same one in all places?
+    even in 1.14 NMS?

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The build can then be found in /IF/target/.
 ## Adventure support
 
 IF supports [Adventure](https://github.com/KyoriPowered/adventure), but does not shade it in itself.
-The use of Adventure `Component`s instead of legacy `String`s completely optional.
+The use of Adventure `Component`s instead of legacy `String`s is completely optional.
 If you do not wish to use Adventure you can safely ignore all `TextHolder` related methods.
 
 ### What is Adventure?

--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ Example of migration from legacy `String` to Adventure `Component`:
 
 We apologize for the boilerplate (the `ComponentHolder.of(...)` call), but that was the only way to not make IF hard-depend on Adventure.
 
-Full Adventure support is only achieved when your server natively supports Adventure.
+Full Adventure support is only achieved when your server natively supports Adventure (it is running Paper) and your plugin depends on Paper (instead of Spigot).
 In other words, you won't benefit from Adventure as much if you use Spigot instead of Paper.
-This is because for Spigot we have to convert everything back to legacy `String`s before passing them to the Bukkit API.
+This is because when Adventure is relocated we have to convert everything back to legacy `String`s before passing them to the Bukkit API.

--- a/adventure-support/pom.xml
+++ b/adventure-support/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>IF-parent</artifactId>
+		<groupId>com.github.stefvanschie.inventoryframework</groupId>
+		<version>0.9.9</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	
+	<artifactId>adventure-support</artifactId>
+	
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+	
+	<repositories>
+		<repository>
+			<id>papermc</id>
+			<url>https://papermc.io/repo/repository/maven-public/</url>
+		</repository>
+	</repositories>
+	
+	<dependencies>
+		<dependency>
+			<groupId>com.destroystokyo.paper</groupId>
+			<artifactId>paper-api</artifactId>
+			<version>1.16.5-R0.1-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.kyori</groupId>
+			<artifactId>adventure-api</artifactId>
+			<version>${adventure.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/adventure-support/pom.xml
+++ b/adventure-support/pom.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
-		<artifactId>IF-parent</artifactId>
-		<groupId>com.github.stefvanschie.inventoryframework</groupId>
-		<version>0.9.9</version>
-	</parent>
-	<modelVersion>4.0.0</modelVersion>
-	
-	<artifactId>adventure-support</artifactId>
-	
-	<properties>
-		<maven.deploy.skip>true</maven.deploy.skip>
-	</properties>
-	
-	<repositories>
-		<repository>
-			<id>papermc</id>
-			<url>https://papermc.io/repo/repository/maven-public/</url>
-		</repository>
-	</repositories>
-	
-	<dependencies>
-		<dependency>
-			<groupId>com.destroystokyo.paper</groupId>
-			<artifactId>paper-api</artifactId>
-			<version>1.16.5-R0.1-SNAPSHOT</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>net.kyori</groupId>
-			<artifactId>adventure-api</artifactId>
-			<version>${adventure.version}</version>
-			<scope>provided</scope>
-		</dependency>
-	</dependencies>
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>IF-parent</artifactId>
+        <groupId>com.github.stefvanschie.inventoryframework</groupId>
+        <version>0.9.9</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    
+    <artifactId>adventure-support</artifactId>
+    
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+    
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
+        </repository>
+    </repositories>
+    
+    <dependencies>
+        <dependency>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>${adventure.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
@@ -11,24 +11,54 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
+/**
+ * Wrapper of an Adventure {@link Component}.
+ *
+ * @since $ADVENTURE-SUPPORT-SINCE$
+ */
 public abstract class ComponentHolder extends TextHolder {
     
+    /**
+     * Whether the server platform natively supports Adventure.
+     * A null value indicates that we don't yet know this: it hasn't been determined yet.
+     * This field should not be used directly, use {@link #isNativeAdventureSupport()} instead.
+     */
+    @Nullable
     private static Boolean nativeAdventureSupport;
     
+    /**
+     * The serializer to use when converting wrapped values to legacy strings.
+     * A null value indicates that we haven't created the serializer yet.
+     * This field should not be used directly, use {@link #getLegacySerializer()} instead.
+     */
+    @Nullable
     private static LegacyComponentSerializer legacySerializer;
     
+    /**
+     * Wraps the specified Adventure component.
+     *
+     * @param value the value to wrap
+     * @return an instance that wraps the specified value
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public static ComponentHolder of(@NotNull Component value) {
         Validate.notNull(value, "value mustn't be null");
         return isNativeAdventureSupport()
-            ? new NativeComponentHolder(value)
-            : new ForeignComponentHolder(value);
+                ? new NativeComponentHolder(value)
+                : new ForeignComponentHolder(value);
     }
     
+    /**
+     * Gets whether the server platform natively supports Adventure.
+     * Native Adventure support means that eg. {@link ItemMeta#displayName(Component)}
+     * is a valid method.
+     */
     private static boolean isNativeAdventureSupport() {
         if (nativeAdventureSupport == null) {
             try {
@@ -55,6 +85,10 @@ public abstract class ComponentHolder extends TextHolder {
         return nativeAdventureSupport;
     }
     
+    /**
+     * Gets the serializer to use when converting wrapped values to legacy strings.
+     * Main use case being the implementation of {@link #asLegacyString()}.
+     */
     private static LegacyComponentSerializer getLegacySerializer() {
         if (legacySerializer == null) {
             LegacyComponentSerializer.Builder builder = LegacyComponentSerializer.builder()
@@ -69,19 +103,39 @@ public abstract class ComponentHolder extends TextHolder {
         return legacySerializer;
     }
     
+    /**
+     * The Adventure component this instance wraps.
+     */
     @NotNull
     protected final Component value;
     
+    /**
+     * Creates and initializes a new instance.
+     *
+     * @param value the Adventure component this instance should wrap
+     */
     ComponentHolder(@NotNull Component value) {
         this.value = value;
     }
     
+    /**
+     * Gets the Adventure component this instance wraps.
+     *
+     * @return the contained Adventure component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public Component getComponent() {
         return value;
     }
     
+    /**
+     * Gets the wrapped Adventure component in a JSON representation.
+     *
+     * @return the contained Adventure component as JSON
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public JsonElement asJson() {
@@ -103,7 +157,7 @@ public abstract class ComponentHolder extends TextHolder {
     @Override
     public boolean equals(Object other) {
         return other != null && getClass() == other.getClass()
-            && Objects.equals(value, ((ComponentHolder) other).value);
+                && Objects.equals(value, ((ComponentHolder) other).value);
     }
     
     @NotNull

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 /**
  * Wrapper of an Adventure {@link Component}.
  *
- * @since $ADVENTURE-SUPPORT-SINCE$
+ * @since 0.10.0
  */
 public abstract class ComponentHolder extends TextHolder {
     
@@ -43,7 +43,7 @@ public abstract class ComponentHolder extends TextHolder {
      *
      * @param value the value to wrap
      * @return an instance that wraps the specified value
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -60,6 +60,7 @@ public abstract class ComponentHolder extends TextHolder {
      * is a valid method.
      *
      * @return whether the server platform natively supports Adventure
+     * @since 0.10.0
      */
     private static boolean isNativeAdventureSupport() {
         if (nativeAdventureSupport == null) {
@@ -92,6 +93,7 @@ public abstract class ComponentHolder extends TextHolder {
      * Main use case being the implementation of {@link #asLegacyString()}.
      *
      * @return a serializer for converting wrapped values to legacy strings
+     * @since 0.10.0
      */
     private static LegacyComponentSerializer getLegacySerializer() {
         if (legacySerializer == null) {
@@ -117,6 +119,7 @@ public abstract class ComponentHolder extends TextHolder {
      * Creates and initializes a new instance.
      *
      * @param value the Adventure component this instance should wrap
+     * @since 0.10.0
      */
     ComponentHolder(@NotNull Component value) {
         this.value = value;
@@ -126,7 +129,7 @@ public abstract class ComponentHolder extends TextHolder {
      * Gets the Adventure component this instance wraps.
      *
      * @return the contained Adventure component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -138,7 +141,7 @@ public abstract class ComponentHolder extends TextHolder {
      * Gets the wrapped Adventure component in a JSON representation.
      *
      * @return the contained Adventure component as JSON
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
@@ -1,0 +1,99 @@
+package com.github.stefvanschie.inventoryframework.adventuresupport;
+
+import com.google.gson.JsonElement;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.apache.commons.lang.Validate;
+import org.bukkit.Bukkit;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class ComponentHolder extends TextHolder {
+    
+    @NotNull
+    @Contract(pure = true)
+    public static ComponentHolder of(@NotNull Component value) {
+        Validate.notNull(value, "value mustn't be null");
+        return new ComponentHolder(value);
+    }
+    
+    @NotNull
+    private final Component value;
+    
+    private ComponentHolder(@NotNull Component value) {
+        this.value = value;
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public JsonElement asJson() {
+        return GsonComponentSerializer.gson().serializeToTree(value);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{" + value + "}";
+    }
+    
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+    
+    @Override
+    public boolean equals(Object other) {
+        return other != null && getClass() == other.getClass()
+            && Objects.equals(value, ((ComponentHolder) other).value);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public String asLegacyString() {
+        return LegacyComponentSerializer.legacySection().serialize(value);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public Component asComponent() {
+        return value;
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public Inventory asInventoryTitle(InventoryHolder holder, InventoryType type) {
+        return Bukkit.createInventory(holder, type, value);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public Inventory asInventoryTitle(InventoryHolder holder, int size) {
+        return Bukkit.createInventory(holder, size, value);
+    }
+    
+    @Override
+    public void asItemDisplayName(ItemMeta meta) {
+        meta.displayName(value);
+    }
+    
+    @Override
+    public void asItemLoreAtEnd(ItemMeta meta) {
+        List<Component> lore = meta.hasLore()
+            ? Objects.requireNonNull(meta.lore())
+            : new ArrayList<>();
+        lore.add(value);
+        meta.lore(lore);
+    }
+}

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
@@ -58,6 +58,8 @@ public abstract class ComponentHolder extends TextHolder {
      * Gets whether the server platform natively supports Adventure.
      * Native Adventure support means that eg. {@link ItemMeta#displayName(Component)}
      * is a valid method.
+     *
+     * @return whether the server platform natively supports Adventure
      */
     private static boolean isNativeAdventureSupport() {
         if (nativeAdventureSupport == null) {
@@ -88,6 +90,8 @@ public abstract class ComponentHolder extends TextHolder {
     /**
      * Gets the serializer to use when converting wrapped values to legacy strings.
      * Main use case being the implementation of {@link #asLegacyString()}.
+     *
+     * @return a serializer for converting wrapped values to legacy strings
      */
     private static LegacyComponentSerializer getLegacySerializer() {
         if (legacySerializer == null) {

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
@@ -62,6 +62,12 @@ public abstract class ComponentHolder extends TextHolder {
     
     @NotNull
     @Contract(pure = true)
+    public Component getComponent() {
+        return value;
+    }
+    
+    @NotNull
+    @Contract(pure = true)
     public JsonElement asJson() {
         return GsonComponentSerializer.gson().serializeToTree(value);
     }

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
@@ -18,6 +18,8 @@ public abstract class ComponentHolder extends TextHolder {
     
     private static Boolean nativeAdventureSupport;
     
+    private static LegacyComponentSerializer legacySerializer;
+    
     @NotNull
     @Contract(pure = true)
     public static ComponentHolder of(@NotNull Component value) {
@@ -51,6 +53,20 @@ public abstract class ComponentHolder extends TextHolder {
             }
         }
         return nativeAdventureSupport;
+    }
+    
+    private static LegacyComponentSerializer getLegacySerializer() {
+        if (legacySerializer == null) {
+            LegacyComponentSerializer.Builder builder = LegacyComponentSerializer.builder()
+                    .character(LegacyComponentSerializer.SECTION_CHAR);
+            if (!net.md_5.bungee.api.ChatColor.class.isEnum()) {
+                //1.16+ Spigot (or Paper), hex colors are supported, no need to down sample them
+                builder.hexColors()
+                        .useUnusualXRepeatedCharacterHexFormat();
+            }
+            legacySerializer = builder.build();
+        }
+        return legacySerializer;
     }
     
     @NotNull
@@ -94,8 +110,6 @@ public abstract class ComponentHolder extends TextHolder {
     @Contract(pure = true)
     @Override
     public String asLegacyString() {
-        //TODO this down samples colors to the nearest ChatColor
-        // is this a bug or a feature?
-        return LegacyComponentSerializer.legacySection().serialize(value);
+        return getLegacySerializer().serialize(value);
     }
 }

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ComponentHolder.java
@@ -86,15 +86,10 @@ public abstract class ComponentHolder extends TextHolder {
     
     @NotNull
     @Contract(pure = true)
+    @Override
     public String asLegacyString() {
         //TODO this down samples colors to the nearest ChatColor
         // is this a bug or a feature?
         return LegacyComponentSerializer.legacySection().serialize(value);
-    }
-    
-    @NotNull
-    @Contract(pure = true)
-    public Component asComponent() {
-        return value;
     }
 }

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ForeignComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ForeignComponentHolder.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
  * Adventure components are converted to legacy Strings before passed to the Bukkit API.
  *
  * @see NativeComponentHolder
+ * @since 0.10.0
  */
 class ForeignComponentHolder extends ComponentHolder {
     
@@ -27,6 +28,7 @@ class ForeignComponentHolder extends ComponentHolder {
      * Creates and initializes a new instance.
      *
      * @param value the Adventure component this instance should wrap
+     * @since 0.10.0
      */
     ForeignComponentHolder(@NotNull Component value) {
         super(value);

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ForeignComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ForeignComponentHolder.java
@@ -8,10 +8,26 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * A {@link ComponentHolder} implementation for platforms where Adventure isn't natively supported.
+ * Adventure components are converted to legacy Strings before passed to the Bukkit API.
+ *
+ * @see NativeComponentHolder
+ */
 class ForeignComponentHolder extends ComponentHolder {
     
+    /**
+     * A {@link StringHolder} wrapping {@link #asLegacyString()}.
+     * This class depends on {@link StringHolder} to reduce code duplication.
+     */
+    @NotNull
     private final StringHolder legacy;
     
+    /**
+     * Creates and initializes a new instance.
+     *
+     * @param value the Adventure component this instance should wrap
+     */
     ForeignComponentHolder(@NotNull Component value) {
         super(value);
         legacy = StringHolder.of(asLegacyString());

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ForeignComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/ForeignComponentHolder.java
@@ -1,0 +1,43 @@
+package com.github.stefvanschie.inventoryframework.adventuresupport;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+class ForeignComponentHolder extends ComponentHolder {
+    
+    private final StringHolder legacy;
+    
+    ForeignComponentHolder(@NotNull Component value) {
+        super(value);
+        legacy = StringHolder.of(asLegacyString());
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public Inventory asInventoryTitle(InventoryHolder holder, InventoryType type) {
+        return legacy.asInventoryTitle(holder, type);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public Inventory asInventoryTitle(InventoryHolder holder, int size) {
+        return legacy.asInventoryTitle(holder, size);
+    }
+    
+    @Override
+    public void asItemDisplayName(ItemMeta meta) {
+        legacy.asItemDisplayName(meta);
+    }
+    
+    @Override
+    public void asItemLoreAtEnd(ItemMeta meta) {
+        legacy.asItemLoreAtEnd(meta);
+    }
+}

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/NativeComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/NativeComponentHolder.java
@@ -1,0 +1,49 @@
+package com.github.stefvanschie.inventoryframework.adventuresupport;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+class NativeComponentHolder extends ComponentHolder {
+    
+    NativeComponentHolder(@NotNull Component value) {
+        super(value);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public Inventory asInventoryTitle(InventoryHolder holder, InventoryType type) {
+        return Bukkit.createInventory(holder, type, value);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public Inventory asInventoryTitle(InventoryHolder holder, int size) {
+        return Bukkit.createInventory(holder, size, value);
+    }
+    
+    @Override
+    public void asItemDisplayName(ItemMeta meta) {
+        meta.displayName(value);
+    }
+    
+    @Override
+    public void asItemLoreAtEnd(ItemMeta meta) {
+        List<Component> lore = meta.hasLore()
+            ? Objects.requireNonNull(meta.lore())
+            : new ArrayList<>();
+        lore.add(value);
+        meta.lore(lore);
+    }
+}

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/NativeComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/NativeComponentHolder.java
@@ -18,6 +18,7 @@ import java.util.Objects;
  * Adventure components are directly passed to the Bukkit (Paper) API.
  *
  * @see ForeignComponentHolder
+ * @since 0.10.0
  */
 class NativeComponentHolder extends ComponentHolder {
     
@@ -25,6 +26,7 @@ class NativeComponentHolder extends ComponentHolder {
      * Creates and initializes a new instance.
      *
      * @param value the Adventure component this instance should wrap
+     * @since 0.10.0
      */
     NativeComponentHolder(@NotNull Component value) {
         super(value);

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/NativeComponentHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/NativeComponentHolder.java
@@ -13,8 +13,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * A {@link ComponentHolder} implementation for platforms where Adventure is natively supported.
+ * Adventure components are directly passed to the Bukkit (Paper) API.
+ *
+ * @see ForeignComponentHolder
+ */
 class NativeComponentHolder extends ComponentHolder {
     
+    /**
+     * Creates and initializes a new instance.
+     *
+     * @param value the Adventure component this instance should wrap
+     */
     NativeComponentHolder(@NotNull Component value) {
         super(value);
     }
@@ -41,8 +52,8 @@ class NativeComponentHolder extends ComponentHolder {
     @Override
     public void asItemLoreAtEnd(ItemMeta meta) {
         List<Component> lore = meta.hasLore()
-            ? Objects.requireNonNull(meta.lore())
-            : new ArrayList<>();
+                ? Objects.requireNonNull(meta.lore())
+                : new ArrayList<>();
         lore.add(value);
         meta.lore(lore);
     }

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/StringHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/StringHolder.java
@@ -13,11 +13,27 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Wrapper of a legacy string value.
+ * {@link org.bukkit.ChatColor} based formatting is used.
+ *
+ * @since $ADVENTURE-SUPPORT-SINCE$
+ */
 public final class StringHolder extends TextHolder {
     
+    /**
+     * Cached instance which wraps an empty {@link String}.
+     */
     @NotNull
     private static final StringHolder EMPTY = StringHolder.of("");
     
+    /**
+     * Wraps the specified legacy string.
+     *
+     * @param value the value to wrap
+     * @return an instance that wraps the specified value
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public static StringHolder of(@NotNull String value) {
@@ -29,6 +45,7 @@ public final class StringHolder extends TextHolder {
      * Gets an instance that contains no characters.
      *
      * @return an instance without any characters
+     * @since $ADVENTURE-SUPPORT-SINCE$
      */
     @NotNull
     @Contract(pure = true)
@@ -36,9 +53,17 @@ public final class StringHolder extends TextHolder {
         return EMPTY;
     }
     
+    /**
+     * The legacy string this instance wraps.
+     */
     @NotNull
     private final String value;
     
+    /**
+     * Creates and initializes a new instance.
+     *
+     * @param value the legacy string this instance should wrap
+     */
     private StringHolder(@NotNull String value) {
         this.value = value;
     }
@@ -58,7 +83,7 @@ public final class StringHolder extends TextHolder {
     @Override
     public boolean equals(Object other) {
         return other != null && getClass() == other.getClass()
-            && Objects.equals(value, ((StringHolder) other).value);
+                && Objects.equals(value, ((StringHolder) other).value);
     }
     
     @NotNull
@@ -94,8 +119,8 @@ public final class StringHolder extends TextHolder {
     public void asItemLoreAtEnd(ItemMeta meta) {
         //noinspection deprecation
         List<String> lore = meta.hasLore()
-            ? Objects.requireNonNull(meta.getLore())
-            : new ArrayList<>();
+                ? Objects.requireNonNull(meta.getLore())
+                : new ArrayList<>();
         lore.add(value);
         //noinspection deprecation
         meta.setLore(lore);

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/StringHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/StringHolder.java
@@ -1,7 +1,5 @@
 package com.github.stefvanschie.inventoryframework.adventuresupport;
 
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.event.inventory.InventoryType;
@@ -65,14 +63,9 @@ public final class StringHolder extends TextHolder {
     
     @NotNull
     @Contract(pure = true)
+    @Override
     public String asLegacyString() {
         return value;
-    }
-    
-    @NotNull
-    @Contract(pure = true)
-    public Component asComponent() {
-        return LegacyComponentSerializer.legacySection().deserialize(value);
     }
     
     @NotNull

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/StringHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/StringHolder.java
@@ -1,0 +1,110 @@
+package com.github.stefvanschie.inventoryframework.adventuresupport;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.apache.commons.lang.Validate;
+import org.bukkit.Bukkit;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class StringHolder extends TextHolder {
+    
+    @NotNull
+    private static final StringHolder EMPTY = StringHolder.of("");
+    
+    @NotNull
+    @Contract(pure = true)
+    public static StringHolder of(@NotNull String value) {
+        Validate.notNull(value, "value mustn't be null");
+        return new StringHolder(value);
+    }
+    
+    /**
+     * Gets an instance that contains no characters.
+     *
+     * @return an instance without any characters
+     */
+    @NotNull
+    @Contract(pure = true)
+    public static StringHolder empty() {
+        return EMPTY;
+    }
+    
+    @NotNull
+    private final String value;
+    
+    private StringHolder(@NotNull String value) {
+        this.value = value;
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{" + value + "}";
+    }
+    
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+    
+    @Override
+    public boolean equals(Object other) {
+        return other != null && getClass() == other.getClass()
+            && Objects.equals(value, ((StringHolder) other).value);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public String asLegacyString() {
+        return value;
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public Component asComponent() {
+        return LegacyComponentSerializer.legacySection().deserialize(value);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public Inventory asInventoryTitle(InventoryHolder holder, InventoryType type) {
+        //noinspection deprecation
+        return Bukkit.createInventory(holder, type, value);
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public Inventory asInventoryTitle(InventoryHolder holder, int size) {
+        //noinspection deprecation
+        return Bukkit.createInventory(holder, size, value);
+    }
+    
+    @Override
+    public void asItemDisplayName(ItemMeta meta) {
+        //noinspection deprecation
+        meta.setDisplayName(value);
+    }
+    
+    @Override
+    public void asItemLoreAtEnd(ItemMeta meta) {
+        //noinspection deprecation
+        List<String> lore = meta.hasLore()
+            ? Objects.requireNonNull(meta.getLore())
+            : new ArrayList<>();
+        lore.add(value);
+        //noinspection deprecation
+        meta.setLore(lore);
+    }
+}

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/StringHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/StringHolder.java
@@ -17,7 +17,7 @@ import java.util.Objects;
  * Wrapper of a legacy string value.
  * {@link org.bukkit.ChatColor} based formatting is used.
  *
- * @since $ADVENTURE-SUPPORT-SINCE$
+ * @since 0.10.0
  */
 public final class StringHolder extends TextHolder {
     
@@ -32,7 +32,7 @@ public final class StringHolder extends TextHolder {
      *
      * @param value the value to wrap
      * @return an instance that wraps the specified value
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -45,7 +45,7 @@ public final class StringHolder extends TextHolder {
      * Gets an instance that contains no characters.
      *
      * @return an instance without any characters
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -63,6 +63,7 @@ public final class StringHolder extends TextHolder {
      * Creates and initializes a new instance.
      *
      * @param value the legacy string this instance should wrap
+     * @since 0.10.0
      */
     private StringHolder(@NotNull String value) {
         this.value = value;

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/TextHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/TextHolder.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @see StringHolder
  * @see ComponentHolder
- * @since $ADVENTURE-SUPPORT-SINCE$
+ * @since 0.10.0
  */
 public abstract class TextHolder {
     
@@ -27,7 +27,7 @@ public abstract class TextHolder {
      * Gets an instance that contains no characters and no formatting.
      *
      * @return an instance without any characters or formatting
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -45,7 +45,7 @@ public abstract class TextHolder {
      *
      * @param string the raw data to deserialize
      * @return an instance containing the text from the string
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -73,7 +73,7 @@ public abstract class TextHolder {
      * keeping the original formatting.
      *
      * @return the wrapped value represented as a legacy string
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -85,7 +85,7 @@ public abstract class TextHolder {
      * @param holder the holder to use for the new inventory
      * @param type the type of inventory to create
      * @return a newly created inventory with the wrapped value as its title
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -97,7 +97,7 @@ public abstract class TextHolder {
      * @param holder the holder to use for the new inventory
      * @param size the count of slots the inventory should have (normal size restrictions apply)
      * @return a newly created inventory with the wrapped value as its title
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -107,7 +107,7 @@ public abstract class TextHolder {
      * Modifies the specified meta: sets the display name to the wrapped value.
      *
      * @param meta the meta whose display name to set
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public abstract void asItemDisplayName(ItemMeta meta);
     
@@ -115,7 +115,7 @@ public abstract class TextHolder {
      * Modifies the specified meta: adds the wrapped value as a new lore line at the end
      *
      * @param meta the meta whose lore to append to
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     public abstract void asItemLoreAtEnd(ItemMeta meta);
 }

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/TextHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/TextHolder.java
@@ -1,6 +1,5 @@
 package com.github.stefvanschie.inventoryframework.adventuresupport;
 
-import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
@@ -8,16 +7,13 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.w3c.dom.Node;
 
 /**
  * Immutable wrapper of a text-like value.
- * Support for both Adventure-based Paper
- * and non-Adventure Spigot is achieved through this class.
- * <p>
- * This class is an implementation detail.
- * It must not be exposed to the users of the IF library.
- * </p>
+ * Support for both Adventure and legacy strings is achieved through this class.
+ *
+ * @see StringHolder
+ * @see ComponentHolder
  */
 public abstract class TextHolder {
     
@@ -33,24 +29,20 @@ public abstract class TextHolder {
     }
     
     /**
-     * Deserializes the specified node's {@link Node#getTextContent()}
-     * as a {@link TextHolder}.
+     * Deserializes the specified {@link String} as a {@link TextHolder}.
      * This method is still WIP and may change drastically in the future:
      * <ul>
-     *     <li>Should it take a {@link Node} or a {@link String} as parameter?</li>
-     *     <li>Are we ever gonna use anything other than {@link Node#getTextContent()}?</li>
-     *     <li>Are we going to use minimessage if it's present?</li>
-     *     <li>Is minimessage going to be opt-in? If yes, how do we opt-in?</li>
+     *     <li>Are we going to use MiniMessage if it's present?</li>
+     *     <li>Is MiniMessage going to be opt-in? If yes, how do we opt-in?</li>
      * </ul>
      *
-     * @param node the node whose text content to deserialize
-     * @return an instance containing the text from the node
+     * @param string the raw data to deserialize
+     * @return an instance containing the text from the string
      */
     @NotNull
     @Contract(pure = true)
-    public static TextHolder fromNodeTextContent(@NotNull Node node) {
-        String legacy = ChatColor.translateAlternateColorCodes('&', node.getTextContent());
-        return StringHolder.of(legacy);
+    public static TextHolder deserialize(@NotNull String string) {
+        return StringHolder.of(ChatColor.translateAlternateColorCodes('&', string));
     }
     
     TextHolder() {
@@ -71,10 +63,6 @@ public abstract class TextHolder {
     @NotNull
     @Contract(pure = true)
     public abstract String asLegacyString();
-    
-    @NotNull
-    @Contract(pure = true)
-    public abstract Component asComponent();
     
     @NotNull
     @Contract(pure = true)

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/TextHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/TextHolder.java
@@ -1,5 +1,6 @@
 package com.github.stefvanschie.inventoryframework.adventuresupport;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
@@ -11,16 +12,22 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Immutable wrapper of a text-like value.
  * Support for both Adventure and legacy strings is achieved through this class.
+ * To get an instance of this class please refer to either {@link StringHolder#of(String)}
+ * or {@link ComponentHolder#of(Component)}.
+ * Other methods like {@link #empty()} and {@link #deserialize(String)}
+ * also exist, but their use cases are very limited.
  *
  * @see StringHolder
  * @see ComponentHolder
+ * @since $ADVENTURE-SUPPORT-SINCE$
  */
 public abstract class TextHolder {
     
     /**
-     * Gets an instance that contains no characters.
+     * Gets an instance that contains no characters and no formatting.
      *
-     * @return an instance without any characters
+     * @return an instance without any characters or formatting
+     * @since $ADVENTURE-SUPPORT-SINCE$
      */
     @NotNull
     @Contract(pure = true)
@@ -38,6 +45,7 @@ public abstract class TextHolder {
      *
      * @param string the raw data to deserialize
      * @return an instance containing the text from the string
+     * @since $ADVENTURE-SUPPORT-SINCE$
      */
     @NotNull
     @Contract(pure = true)
@@ -60,19 +68,54 @@ public abstract class TextHolder {
     @Override
     public abstract boolean equals(Object other);
     
+    /**
+     * Converts the text wrapped by this class instance to a legacy string,
+     * keeping the original formatting.
+     *
+     * @return the wrapped value represented as a legacy string
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public abstract String asLegacyString();
     
+    /**
+     * Creates a new inventory with the wrapped value as the inventory's title.
+     *
+     * @param holder the holder to use for the new inventory
+     * @param type the type of inventory to create
+     * @return a newly created inventory with the wrapped value as its title
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public abstract Inventory asInventoryTitle(InventoryHolder holder, InventoryType type);
     
+    /**
+     * Creates a new inventory with the wrapped value as the inventory's title.
+     *
+     * @param holder the holder to use for the new inventory
+     * @param size the count of slots the inventory should have (normal size restrictions apply)
+     * @return a newly created inventory with the wrapped value as its title
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public abstract Inventory asInventoryTitle(InventoryHolder holder, int size);
     
+    /**
+     * Modifies the specified meta: sets the display name to the wrapped value.
+     *
+     * @param meta the meta whose display name to set
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public abstract void asItemDisplayName(ItemMeta meta);
     
+    /**
+     * Modifies the specified meta: adds the wrapped value as a new lore line at the end
+     *
+     * @param meta the meta whose lore to append to
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     public abstract void asItemLoreAtEnd(ItemMeta meta);
 }

--- a/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/TextHolder.java
+++ b/adventure-support/src/main/java/com/github/stefvanschie/inventoryframework/adventuresupport/TextHolder.java
@@ -1,0 +1,90 @@
+package com.github.stefvanschie.inventoryframework.adventuresupport;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.ChatColor;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.w3c.dom.Node;
+
+/**
+ * Immutable wrapper of a text-like value.
+ * Support for both Adventure-based Paper
+ * and non-Adventure Spigot is achieved through this class.
+ * <p>
+ * This class is an implementation detail.
+ * It must not be exposed to the users of the IF library.
+ * </p>
+ */
+public abstract class TextHolder {
+    
+    /**
+     * Gets an instance that contains no characters.
+     *
+     * @return an instance without any characters
+     */
+    @NotNull
+    @Contract(pure = true)
+    public static TextHolder empty() {
+        return StringHolder.empty();
+    }
+    
+    /**
+     * Deserializes the specified node's {@link Node#getTextContent()}
+     * as a {@link TextHolder}.
+     * This method is still WIP and may change drastically in the future:
+     * <ul>
+     *     <li>Should it take a {@link Node} or a {@link String} as parameter?</li>
+     *     <li>Are we ever gonna use anything other than {@link Node#getTextContent()}?</li>
+     *     <li>Are we going to use minimessage if it's present?</li>
+     *     <li>Is minimessage going to be opt-in? If yes, how do we opt-in?</li>
+     * </ul>
+     *
+     * @param node the node whose text content to deserialize
+     * @return an instance containing the text from the node
+     */
+    @NotNull
+    @Contract(pure = true)
+    public static TextHolder fromNodeTextContent(@NotNull Node node) {
+        String legacy = ChatColor.translateAlternateColorCodes('&', node.getTextContent());
+        return StringHolder.of(legacy);
+    }
+    
+    TextHolder() {
+        //package-private constructor to "seal" the class
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    @Override
+    public abstract String toString();
+    
+    @Override
+    public abstract int hashCode();
+    
+    @Override
+    public abstract boolean equals(Object other);
+    
+    @NotNull
+    @Contract(pure = true)
+    public abstract String asLegacyString();
+    
+    @NotNull
+    @Contract(pure = true)
+    public abstract Component asComponent();
+    
+    @NotNull
+    @Contract(pure = true)
+    public abstract Inventory asInventoryTitle(InventoryHolder holder, InventoryType type);
+    
+    @NotNull
+    @Contract(pure = true)
+    public abstract Inventory asInventoryTitle(InventoryHolder holder, int size);
+    
+    public abstract void asItemDisplayName(ItemMeta meta);
+    
+    public abstract void asItemLoreAtEnd(ItemMeta meta);
+}

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/AnvilInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/AnvilInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
@@ -28,7 +30,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -44,7 +46,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/AnvilInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/AnvilInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
@@ -46,7 +46,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/CartographyTableInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/CartographyTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -45,7 +47,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/CartographyTableInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/CartographyTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventory;
@@ -47,7 +47,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/EnchantingTableInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/EnchantingTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/EnchantingTableInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/EnchantingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/GrindstoneInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/GrindstoneInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/GrindstoneInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/GrindstoneInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/StonecutterInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/StonecutterInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/StonecutterInventoryImpl.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/StonecutterInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_14_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_14_R1.*;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/util/AdventureSupportUtil.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/util/AdventureSupportUtil.java
@@ -1,0 +1,40 @@
+package com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util;
+
+import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import net.minecraft.server.v1_14_R1.ChatComponentText;
+import net.minecraft.server.v1_14_R1.IChatBaseComponent;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public final class AdventureSupportUtil {
+    
+    private AdventureSupportUtil() {
+        //private constructor to prevent construction
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
+        if (holder instanceof StringHolder) {
+            return toComponent((StringHolder) holder);
+        } else {
+            return toComponent((ComponentHolder) holder);
+        }
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
+        return new ChatComponentText(holder.asLegacyString());
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {
+        return Objects.requireNonNull(IChatBaseComponent.ChatSerializer.a(holder.asJson()));
+    }
+}

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/util/TextHolderUtil.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/util/TextHolderUtil.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 /**
  * A utility class for adding {@link TextHolder} support.
  *
- * @since $ADVENTURE-SUPPORT-SINCE$
+ * @since 0.10.0
  */
 public final class TextHolderUtil {
     
@@ -26,7 +26,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -43,7 +43,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -56,7 +56,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)

--- a/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/util/TextHolderUtil.java
+++ b/nms/1_14_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_14_R1/util/TextHolderUtil.java
@@ -1,21 +1,33 @@
-package com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util;
+package com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util;
 
 import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import net.minecraft.server.v1_16_R1.ChatComponentText;
-import net.minecraft.server.v1_16_R1.IChatBaseComponent;
+import net.minecraft.server.v1_14_R1.ChatComponentText;
+import net.minecraft.server.v1_14_R1.IChatBaseComponent;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public final class AdventureSupportUtil {
+/**
+ * A utility class for adding {@link TextHolder} support.
+ *
+ * @since $ADVENTURE-SUPPORT-SINCE$
+ */
+public final class TextHolderUtil {
     
-    private AdventureSupportUtil() {
+    private TextHolderUtil() {
         //private constructor to prevent construction
     }
     
+    /**
+     * Converts the specified value to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
@@ -26,12 +38,26 @@ public final class AdventureSupportUtil {
         }
     }
     
+    /**
+     * Converts the specified legacy string holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
         return new ChatComponentText(holder.asLegacyString());
     }
     
+    /**
+     * Converts the specified Adventure component holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/AnvilInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/AnvilInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
@@ -28,7 +30,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -44,7 +46,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/AnvilInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/AnvilInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
@@ -46,7 +46,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/CartographyTableInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/CartographyTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory;
@@ -47,7 +47,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY_TABLE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/CartographyTableInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/CartographyTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -45,7 +47,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY_TABLE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/EnchantingTableInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/EnchantingTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/EnchantingTableInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/EnchantingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/GrindstoneInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/GrindstoneInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/GrindstoneInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/GrindstoneInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/StonecutterInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/StonecutterInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/StonecutterInventoryImpl.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/StonecutterInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_15_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/util/AdventureSupportUtil.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/util/AdventureSupportUtil.java
@@ -1,0 +1,40 @@
+package com.github.stefvanschie.inventoryframework.nms.v1_15_R1.util;
+
+import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import net.minecraft.server.v1_15_R1.ChatComponentText;
+import net.minecraft.server.v1_15_R1.IChatBaseComponent;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public final class AdventureSupportUtil {
+    
+    private AdventureSupportUtil() {
+        //private constructor to prevent construction
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
+        if (holder instanceof StringHolder) {
+            return toComponent((StringHolder) holder);
+        } else {
+            return toComponent((ComponentHolder) holder);
+        }
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
+        return new ChatComponentText(holder.asLegacyString());
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {
+        return Objects.requireNonNull(IChatBaseComponent.ChatSerializer.a(holder.asJson()));
+    }
+}

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/util/TextHolderUtil.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/util/TextHolderUtil.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 /**
  * A utility class for adding {@link TextHolder} support.
  *
- * @since $ADVENTURE-SUPPORT-SINCE$
+ * @since 0.10.0
  */
 public final class TextHolderUtil {
     
@@ -26,7 +26,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -43,7 +43,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -56,7 +56,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)

--- a/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/util/TextHolderUtil.java
+++ b/nms/1_15_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_15_R1/util/TextHolderUtil.java
@@ -10,12 +10,24 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public final class AdventureSupportUtil {
+/**
+ * A utility class for adding {@link TextHolder} support.
+ *
+ * @since $ADVENTURE-SUPPORT-SINCE$
+ */
+public final class TextHolderUtil {
     
-    private AdventureSupportUtil() {
+    private TextHolderUtil() {
         //private constructor to prevent construction
     }
     
+    /**
+     * Converts the specified value to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
@@ -26,12 +38,26 @@ public final class AdventureSupportUtil {
         }
     }
     
+    /**
+     * Converts the specified legacy string holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
         return new ChatComponentText(holder.asLegacyString());
     }
     
+    /**
+     * Converts the specified Adventure component holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/AnvilInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/AnvilInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
@@ -26,7 +28,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -42,7 +44,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/AnvilInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/AnvilInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
@@ -44,7 +44,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/CartographyTableInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/CartographyTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -45,7 +47,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY_TABLE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/CartographyTableInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/CartographyTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -47,7 +47,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY_TABLE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/EnchantingTableInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/EnchantingTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/EnchantingTableInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/EnchantingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/GrindstoneInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/GrindstoneInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/GrindstoneInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/GrindstoneInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/SmithingTableInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/SmithingTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.SmithingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -25,7 +27,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -41,7 +43,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
         entityPlayer.activeContainer = containerSmithingTable;
 
         int id = containerSmithingTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.SMITHING, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/SmithingTableInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/SmithingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.SmithingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -43,7 +43,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
         entityPlayer.activeContainer = containerSmithingTable;
 
         int id = containerSmithingTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.SMITHING, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/StonecutterInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/StonecutterInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/StonecutterInventoryImpl.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/StonecutterInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/util/AdventureSupportUtil.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/util/AdventureSupportUtil.java
@@ -1,0 +1,40 @@
+package com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util;
+
+import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import net.minecraft.server.v1_16_R1.ChatComponentText;
+import net.minecraft.server.v1_16_R1.IChatBaseComponent;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public final class AdventureSupportUtil {
+    
+    private AdventureSupportUtil() {
+        //private constructor to prevent construction
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
+        if (holder instanceof StringHolder) {
+            return toComponent((StringHolder) holder);
+        } else {
+            return toComponent((ComponentHolder) holder);
+        }
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
+        return new ChatComponentText(holder.asLegacyString());
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {
+        return Objects.requireNonNull(IChatBaseComponent.ChatSerializer.a(holder.asJson()));
+    }
+}

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/util/TextHolderUtil.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/util/TextHolderUtil.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 /**
  * A utility class for adding {@link TextHolder} support.
  *
- * @since $ADVENTURE-SUPPORT-SINCE$
+ * @since 0.10.0
  */
 public final class TextHolderUtil {
     
@@ -26,7 +26,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -43,7 +43,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -56,7 +56,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)

--- a/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/util/TextHolderUtil.java
+++ b/nms/1_16_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R1/util/TextHolderUtil.java
@@ -1,21 +1,33 @@
-package com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util;
+package com.github.stefvanschie.inventoryframework.nms.v1_16_R1.util;
 
 import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import net.minecraft.server.v1_16_R2.ChatComponentText;
-import net.minecraft.server.v1_16_R2.IChatBaseComponent;
+import net.minecraft.server.v1_16_R1.ChatComponentText;
+import net.minecraft.server.v1_16_R1.IChatBaseComponent;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public final class AdventureSupportUtil {
+/**
+ * A utility class for adding {@link TextHolder} support.
+ *
+ * @since $ADVENTURE-SUPPORT-SINCE$
+ */
+public final class TextHolderUtil {
     
-    private AdventureSupportUtil() {
+    private TextHolderUtil() {
         //private constructor to prevent construction
     }
     
+    /**
+     * Converts the specified value to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
@@ -26,12 +38,26 @@ public final class AdventureSupportUtil {
         }
     }
     
+    /**
+     * Converts the specified legacy string holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
         return new ChatComponentText(holder.asLegacyString());
     }
     
+    /**
+     * Converts the specified Adventure component holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/AnvilInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/AnvilInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
@@ -44,7 +44,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/AnvilInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/AnvilInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
@@ -26,7 +28,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -42,7 +44,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/CartographyTableInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/CartographyTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -44,7 +44,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY_TABLE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/CartographyTableInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/CartographyTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -24,7 +26,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -42,7 +44,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY_TABLE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/EnchantingTableInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/EnchantingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -42,7 +42,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/EnchantingTableInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/EnchantingTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -24,7 +26,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -40,7 +42,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/GrindstoneInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/GrindstoneInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -42,7 +42,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/GrindstoneInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/GrindstoneInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -24,7 +26,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -40,7 +42,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/SmithingTableInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/SmithingTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.SmithingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -22,7 +24,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -38,7 +40,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
         entityPlayer.activeContainer = containerSmithingTable;
 
         int id = containerSmithingTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.SMITHING, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/SmithingTableInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/SmithingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.SmithingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -40,7 +40,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
         entityPlayer.activeContainer = containerSmithingTable;
 
         int id = containerSmithingTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.SMITHING, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/StonecutterInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/StonecutterInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -42,7 +42,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/StonecutterInventoryImpl.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/StonecutterInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R2;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R2.inventory.*;
@@ -24,7 +26,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -40,7 +42,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/util/AdventureSupportUtil.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/util/AdventureSupportUtil.java
@@ -1,0 +1,40 @@
+package com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util;
+
+import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import net.minecraft.server.v1_16_R2.ChatComponentText;
+import net.minecraft.server.v1_16_R2.IChatBaseComponent;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public final class AdventureSupportUtil {
+    
+    private AdventureSupportUtil() {
+        //private constructor to prevent construction
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
+        if (holder instanceof StringHolder) {
+            return toComponent((StringHolder) holder);
+        } else {
+            return toComponent((ComponentHolder) holder);
+        }
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
+        return new ChatComponentText(holder.asLegacyString());
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {
+        return Objects.requireNonNull(IChatBaseComponent.ChatSerializer.a(holder.asJson()));
+    }
+}

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/util/TextHolderUtil.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/util/TextHolderUtil.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 /**
  * A utility class for adding {@link TextHolder} support.
  *
- * @since $ADVENTURE-SUPPORT-SINCE$
+ * @since 0.10.0
  */
 public final class TextHolderUtil {
     
@@ -26,7 +26,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -43,7 +43,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -56,7 +56,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)

--- a/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/util/TextHolderUtil.java
+++ b/nms/1_16_R2/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R2/util/TextHolderUtil.java
@@ -1,21 +1,33 @@
-package com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util;
+package com.github.stefvanschie.inventoryframework.nms.v1_16_R2.util;
 
 import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import net.minecraft.server.v1_16_R3.ChatComponentText;
-import net.minecraft.server.v1_16_R3.IChatBaseComponent;
+import net.minecraft.server.v1_16_R2.ChatComponentText;
+import net.minecraft.server.v1_16_R2.IChatBaseComponent;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public final class AdventureSupportUtil {
+/**
+ * A utility class for adding {@link TextHolder} support.
+ *
+ * @since $ADVENTURE-SUPPORT-SINCE$
+ */
+public final class TextHolderUtil {
     
-    private AdventureSupportUtil() {
+    private TextHolderUtil() {
         //private constructor to prevent construction
     }
     
+    /**
+     * Converts the specified value to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
@@ -26,12 +38,26 @@ public final class AdventureSupportUtil {
         }
     }
     
+    /**
+     * Converts the specified legacy string holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
         return new ChatComponentText(holder.asLegacyString());
     }
     
+    /**
+     * Converts the specified Adventure component holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/AnvilInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/AnvilInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
@@ -26,7 +28,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -42,7 +44,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/AnvilInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/AnvilInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
@@ -44,7 +44,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         entityPlayer.activeContainer = containerAnvil;
 
         int id = containerAnvil.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
 
         entityPlayer.playerConnection.sendPacket(new PacketPlayOutOpenWindow(id, Containers.ANVIL, message));
 

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/CartographyTableInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/CartographyTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -45,7 +47,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY_TABLE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/CartographyTableInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/CartographyTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -47,7 +47,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         entityPlayer.activeContainer = containerCartographyTable;
 
         int id = containerCartographyTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.CARTOGRAPHY_TABLE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/EnchantingTableInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/EnchantingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/EnchantingTableInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/EnchantingTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.ENCHANTMENT, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/GrindstoneInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/GrindstoneInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/GrindstoneInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/GrindstoneInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         entityPlayer.activeContainer = containerGrindstone;
 
         int id = containerGrindstone.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.GRINDSTONE, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/SmithingTableInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/SmithingTableInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.SmithingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -25,7 +27,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -41,7 +43,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
         entityPlayer.activeContainer = containerSmithingTable;
 
         int id = containerSmithingTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.SMITHING, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/SmithingTableInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/SmithingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.SmithingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -43,7 +43,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
         entityPlayer.activeContainer = containerSmithingTable;
 
         int id = containerSmithingTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.SMITHING, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/StonecutterInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/StonecutterInventoryImpl.java
@@ -1,6 +1,8 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -27,7 +29,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -43,7 +45,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        ChatMessage message = new ChatMessage(title);
+        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/StonecutterInventoryImpl.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/StonecutterInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_16_R3;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util.TextHolderUtil;
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
@@ -45,7 +45,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         entityPlayer.activeContainer = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.windowId;
-        IChatBaseComponent message = AdventureSupportUtil.toComponent(title);
+        IChatBaseComponent message = TextHolderUtil.toComponent(title);
         PacketPlayOutOpenWindow packet = new PacketPlayOutOpenWindow(id, Containers.STONECUTTER, message);
 
         entityPlayer.playerConnection.sendPacket(packet);

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/util/AdventureSupportUtil.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/util/AdventureSupportUtil.java
@@ -1,0 +1,40 @@
+package com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util;
+
+import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import net.minecraft.server.v1_16_R3.ChatComponentText;
+import net.minecraft.server.v1_16_R3.IChatBaseComponent;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public final class AdventureSupportUtil {
+    
+    private AdventureSupportUtil() {
+        //private constructor to prevent construction
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
+        if (holder instanceof StringHolder) {
+            return toComponent((StringHolder) holder);
+        } else {
+            return toComponent((ComponentHolder) holder);
+        }
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
+        return new ChatComponentText(holder.asLegacyString());
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {
+        return Objects.requireNonNull(IChatBaseComponent.ChatSerializer.a(holder.asJson()));
+    }
+}

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/util/TextHolderUtil.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/util/TextHolderUtil.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 /**
  * A utility class for adding {@link TextHolder} support.
  *
- * @since $ADVENTURE-SUPPORT-SINCE$
+ * @since 0.10.0
  */
 public final class TextHolderUtil {
     
@@ -26,7 +26,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -43,7 +43,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -56,7 +56,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)

--- a/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/util/TextHolderUtil.java
+++ b/nms/1_16_R3/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_16_R3/util/TextHolderUtil.java
@@ -1,21 +1,33 @@
-package com.github.stefvanschie.inventoryframework.nms.v1_14_R1.util;
+package com.github.stefvanschie.inventoryframework.nms.v1_16_R3.util;
 
 import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import net.minecraft.server.v1_14_R1.ChatComponentText;
-import net.minecraft.server.v1_14_R1.IChatBaseComponent;
+import net.minecraft.server.v1_16_R3.ChatComponentText;
+import net.minecraft.server.v1_16_R3.IChatBaseComponent;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public final class AdventureSupportUtil {
+/**
+ * A utility class for adding {@link TextHolder} support.
+ *
+ * @since $ADVENTURE-SUPPORT-SINCE$
+ */
+public final class TextHolderUtil {
     
-    private AdventureSupportUtil() {
+    private TextHolderUtil() {
         //private constructor to prevent construction
     }
     
+    /**
+     * Converts the specified value to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public static IChatBaseComponent toComponent(@NotNull TextHolder holder) {
@@ -26,12 +38,26 @@ public final class AdventureSupportUtil {
         }
     }
     
+    /**
+     * Converts the specified legacy string holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull StringHolder holder) {
         return new ChatComponentText(holder.asLegacyString());
     }
     
+    /**
+     * Converts the specified Adventure component holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static IChatBaseComponent toComponent(@NotNull ComponentHolder holder) {

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/AnvilInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/AnvilInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.TextHolderUtil;
 import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.CustomInventoryUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
@@ -57,7 +57,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         serverPlayer.containerMenu = containerAnvil;
 
         int id = containerAnvil.containerId;
-        Component message = AdventureSupportUtil.toComponent(title);
+        Component message = TextHolderUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.ANVIL, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/AnvilInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/AnvilInventoryImpl.java
@@ -1,10 +1,12 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.AnvilInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
 import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.CustomInventoryUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
@@ -39,7 +41,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -55,7 +57,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         serverPlayer.containerMenu = containerAnvil;
 
         int id = containerAnvil.containerId;
-        TranslatableComponent message = new TranslatableComponent(title);
+        Component message = AdventureSupportUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.ANVIL, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/CartographyTableInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/CartographyTableInventoryImpl.java
@@ -1,9 +1,11 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
 import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.CustomInventoryUtil;
 import net.minecraft.core.NonNullList;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
@@ -38,7 +40,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -56,7 +58,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         serverPlayer.containerMenu = containerCartographyTable;
 
         int id = containerCartographyTable.containerId;
-        TranslatableComponent message = new TranslatableComponent(title);
+        Component message = AdventureSupportUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.CARTOGRAPHY_TABLE, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/CartographyTableInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/CartographyTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.CartographyTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.TextHolderUtil;
 import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.CustomInventoryUtil;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
@@ -58,7 +58,7 @@ public class CartographyTableInventoryImpl extends CartographyTableInventory {
         serverPlayer.containerMenu = containerCartographyTable;
 
         int id = containerCartographyTable.containerId;
-        Component message = AdventureSupportUtil.toComponent(title);
+        Component message = TextHolderUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.CARTOGRAPHY_TABLE, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/EnchantingTableInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/EnchantingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.TextHolderUtil;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
@@ -55,7 +55,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         serverPlayer.containerMenu = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.containerId;
-        Component message = AdventureSupportUtil.toComponent(title);
+        Component message = TextHolderUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.ENCHANTMENT, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/EnchantingTableInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/EnchantingTableInventoryImpl.java
@@ -1,8 +1,10 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.EnchantingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
 import net.minecraft.core.NonNullList;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
@@ -37,7 +39,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -53,7 +55,7 @@ public class EnchantingTableInventoryImpl extends EnchantingTableInventory {
         serverPlayer.containerMenu = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.containerId;
-        TranslatableComponent message = new TranslatableComponent(title);
+        Component message = AdventureSupportUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.ENCHANTMENT, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/GrindstoneInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/GrindstoneInventoryImpl.java
@@ -1,9 +1,11 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
 import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.CustomInventoryUtil;
 import net.minecraft.core.NonNullList;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
@@ -38,7 +40,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -54,7 +56,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         serverPlayer.containerMenu = containerGrindstone;
 
         int id = containerGrindstone.containerId;
-        TranslatableComponent message = new TranslatableComponent(title);
+        Component message = AdventureSupportUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.GRINDSTONE, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/GrindstoneInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/GrindstoneInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.GrindstoneInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.TextHolderUtil;
 import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.CustomInventoryUtil;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
@@ -56,7 +56,7 @@ public class GrindstoneInventoryImpl extends GrindstoneInventory {
         serverPlayer.containerMenu = containerGrindstone;
 
         int id = containerGrindstone.containerId;
-        Component message = AdventureSupportUtil.toComponent(title);
+        Component message = TextHolderUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.GRINDSTONE, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/SmithingTableInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/SmithingTableInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.SmithingTableInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.TextHolderUtil;
 import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.CustomInventoryUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
@@ -56,7 +56,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
         serverPlayer.containerMenu = containerSmithingTable;
 
         int id = containerSmithingTable.containerId;
-        Component message = AdventureSupportUtil.toComponent(title);
+        Component message = TextHolderUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.SMITHING, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/SmithingTableInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/SmithingTableInventoryImpl.java
@@ -1,10 +1,12 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.SmithingTableInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
 import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.CustomInventoryUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
@@ -38,7 +40,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -54,7 +56,7 @@ public class SmithingTableInventoryImpl extends SmithingTableInventory {
         serverPlayer.containerMenu = containerSmithingTable;
 
         int id = containerSmithingTable.containerId;
-        TranslatableComponent message = new TranslatableComponent(title);
+        Component message = AdventureSupportUtil.toComponent(title);
 
         serverPlayer.connection.send(new ClientboundOpenScreenPacket(id, MenuType.SMITHING, message));
 

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/StonecutterInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/StonecutterInventoryImpl.java
@@ -1,8 +1,10 @@
 package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
 import net.minecraft.core.NonNullList;
-import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
@@ -37,7 +39,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
     }
 
     @Override
-    public void openInventory(@NotNull Player player, @NotNull String title,
+    public void openInventory(@NotNull Player player, @NotNull TextHolder title,
                               @Nullable org.bukkit.inventory.ItemStack[] items) {
         int itemAmount = items.length;
 
@@ -53,7 +55,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         serverPlayer.containerMenu = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.containerId;
-        TranslatableComponent message = new TranslatableComponent(title);
+        Component message = AdventureSupportUtil.toComponent(title);
         ClientboundOpenScreenPacket packet = new ClientboundOpenScreenPacket(id, MenuType.STONECUTTER, message);
 
         serverPlayer.connection.send(packet);

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/StonecutterInventoryImpl.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/StonecutterInventoryImpl.java
@@ -2,7 +2,7 @@ package com.github.stefvanschie.inventoryframework.nms.v1_17_R1;
 
 import com.github.stefvanschie.inventoryframework.abstraction.StonecutterInventory;
 import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
-import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.AdventureSupportUtil;
+import com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util.TextHolderUtil;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
@@ -55,7 +55,7 @@ public class StonecutterInventoryImpl extends StonecutterInventory {
         serverPlayer.containerMenu = containerEnchantmentTable;
 
         int id = containerEnchantmentTable.containerId;
-        Component message = AdventureSupportUtil.toComponent(title);
+        Component message = TextHolderUtil.toComponent(title);
         ClientboundOpenScreenPacket packet = new ClientboundOpenScreenPacket(id, MenuType.STONECUTTER, message);
 
         serverPlayer.connection.send(packet);

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/util/AdventureSupportUtil.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/util/AdventureSupportUtil.java
@@ -1,0 +1,40 @@
+package com.github.stefvanschie.inventoryframework.nms.v1_17_R1.util;
+
+import com.github.stefvanschie.inventoryframework.adventuresupport.ComponentHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public final class AdventureSupportUtil {
+    
+    private AdventureSupportUtil() {
+        //private constructor to prevent construction
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    public static Component toComponent(@NotNull TextHolder holder) {
+        if (holder instanceof StringHolder) {
+            return toComponent((StringHolder) holder);
+        } else {
+            return toComponent((ComponentHolder) holder);
+        }
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static Component toComponent(@NotNull StringHolder holder) {
+        return new TextComponent(holder.asLegacyString());
+    }
+    
+    @NotNull
+    @Contract(pure = true)
+    private static Component toComponent(@NotNull ComponentHolder holder) {
+        return Objects.requireNonNull(Component.Serializer.fromJson(holder.asJson()));
+    }
+}

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/util/TextHolderUtil.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/util/TextHolderUtil.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 /**
  * A utility class for adding {@link TextHolder} support.
  *
- * @since $ADVENTURE-SUPPORT-SINCE$
+ * @since 0.10.0
  */
 public final class TextHolderUtil {
     
@@ -26,7 +26,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -43,7 +43,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)
@@ -56,7 +56,7 @@ public final class TextHolderUtil {
      *
      * @param holder the value to convert
      * @return the value as a vanilla component
-     * @since $ADVENTURE-SUPPORT-SINCE$
+     * @since 0.10.0
      */
     @NotNull
     @Contract(pure = true)

--- a/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/util/TextHolderUtil.java
+++ b/nms/1_17_R1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v1_17_R1/util/TextHolderUtil.java
@@ -10,12 +10,24 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public final class AdventureSupportUtil {
+/**
+ * A utility class for adding {@link TextHolder} support.
+ *
+ * @since $ADVENTURE-SUPPORT-SINCE$
+ */
+public final class TextHolderUtil {
     
-    private AdventureSupportUtil() {
+    private TextHolderUtil() {
         //private constructor to prevent construction
     }
     
+    /**
+     * Converts the specified value to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     public static Component toComponent(@NotNull TextHolder holder) {
@@ -26,12 +38,26 @@ public final class AdventureSupportUtil {
         }
     }
     
+    /**
+     * Converts the specified legacy string holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static Component toComponent(@NotNull StringHolder holder) {
         return new TextComponent(holder.asLegacyString());
     }
     
+    /**
+     * Converts the specified Adventure component holder to a vanilla component.
+     *
+     * @param holder the value to convert
+     * @return the value as a vanilla component
+     * @since $ADVENTURE-SUPPORT-SINCE$
+     */
     @NotNull
     @Contract(pure = true)
     private static Component toComponent(@NotNull ComponentHolder holder) {

--- a/nms/abstraction/pom.xml
+++ b/nms/abstraction/pom.xml
@@ -25,6 +25,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.github.stefvanschie.inventoryframework</groupId>
+            <artifactId>adventure-support</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.4-R0.1-SNAPSHOT</version>

--- a/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/AnvilInventory.java
+++ b/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/AnvilInventory.java
@@ -1,5 +1,7 @@
 package com.github.stefvanschie.inventoryframework.abstraction;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -44,7 +46,11 @@ public abstract class AnvilInventory {
      * @param items the items to show
      * @since 0.8.0
      */
-    public abstract void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items);
+    public final void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items) {
+        openInventory(player, StringHolder.of(title), items);
+    }
+
+    public abstract void openInventory(@NotNull Player player, @NotNull TextHolder title, @Nullable ItemStack[] items);
 
     /**
      * Sends the top items to the inventory for the specified player.

--- a/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/CartographyTableInventory.java
+++ b/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/CartographyTableInventory.java
@@ -1,5 +1,7 @@
 package com.github.stefvanschie.inventoryframework.abstraction;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -37,7 +39,11 @@ public abstract class CartographyTableInventory {
      * @param items the top items of the inventory
      * @since 0.8.0
      */
-    public abstract void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items);
+    public final void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items) {
+        openInventory(player, StringHolder.of(title), items);
+    }
+
+    public abstract void openInventory(@NotNull Player player, @NotNull TextHolder title, @Nullable ItemStack[] items);
 
     /**
      * Sends the top items to the inventory for the specified player.

--- a/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/EnchantingTableInventory.java
+++ b/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/EnchantingTableInventory.java
@@ -1,5 +1,7 @@
 package com.github.stefvanschie.inventoryframework.abstraction;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -37,7 +39,11 @@ public abstract class EnchantingTableInventory {
      * @param items the top items
      * @since 0.8.0
      */
-    public abstract void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items);
+    public final void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items) {
+        openInventory(player, StringHolder.of(title), items);
+    }
+
+    public abstract void openInventory(@NotNull Player player, @NotNull TextHolder title, @Nullable ItemStack[] items);
 
     /**
      * Sends the top items to the inventory for the specified player.

--- a/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/GrindstoneInventory.java
+++ b/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/GrindstoneInventory.java
@@ -1,5 +1,7 @@
 package com.github.stefvanschie.inventoryframework.abstraction;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -37,7 +39,11 @@ public abstract class GrindstoneInventory {
      * @param items the top items
      * @since 0.8.0
      */
-    public abstract void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items);
+    public final void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items) {
+        openInventory(player, StringHolder.of(title), items);
+    }
+
+    public abstract void openInventory(@NotNull Player player, @NotNull TextHolder title, @Nullable ItemStack[] items);
 
     /**
      * Sends the top items to the inventory for the specified player.

--- a/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/SmithingTableInventory.java
+++ b/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/SmithingTableInventory.java
@@ -1,5 +1,7 @@
 package com.github.stefvanschie.inventoryframework.abstraction;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -37,7 +39,11 @@ public abstract class SmithingTableInventory {
      * @param items the top items
      * @since 0.8.0
      */
-    public abstract void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items);
+    public final void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items) {
+        openInventory(player, StringHolder.of(title), items);
+    }
+
+    public abstract void openInventory(@NotNull Player player, @NotNull TextHolder title, @Nullable ItemStack[] items);
 
     /**
      * Sends the top items to the inventory for the specified player.

--- a/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/StonecutterInventory.java
+++ b/nms/abstraction/src/main/java/com/github/stefvanschie/inventoryframework/abstraction/StonecutterInventory.java
@@ -1,5 +1,7 @@
 package com.github.stefvanschie.inventoryframework.abstraction;
 
+import com.github.stefvanschie.inventoryframework.adventuresupport.StringHolder;
+import com.github.stefvanschie.inventoryframework.adventuresupport.TextHolder;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -37,7 +39,11 @@ public abstract class StonecutterInventory {
      * @param items the top items
      * @since 0.8.0
      */
-    public abstract void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items);
+    public final void openInventory(@NotNull Player player, @NotNull String title, @Nullable ItemStack[] items) {
+        openInventory(player, StringHolder.of(title), items);
+    }
+
+    public abstract void openInventory(@NotNull Player player, @NotNull TextHolder title, @Nullable ItemStack[] items);
 
     /**
      * Sends the top items to the inventory for the specified player.

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <module>nms/1_16_R1</module>
         <module>nms/1_15_R1</module>
         <module>nms/1_14_R1</module>
+        <module>adventure-support</module>
     </modules>
 
     <properties>
@@ -20,6 +21,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.deploy.skip>true</maven.deploy.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <adventure.version>4.8.1</adventure.version>
     </properties>
 
     <groupId>com.github.stefvanschie.inventoryframework</groupId>


### PR DESCRIPTION
Fixes #117 

Future work:
 - This PR does not add proper Adventure support to XML-based GUI declarations: texts in XML files get parsed as legacy strings, there is no way currently to parse them as Adventure components. But changes were introduced to make adding XML Adventure support easy.

Breaking changes: 
 - `NamedGui#createInventory(String)` was removed: it didn't need to exist and adding Adventure support was a bit easier this way.
 - `Gui#createInventory` was made protected (also changed in subclasses): I believe making it `public` was a mistake, but I also could have just left it like that...

Why this PR is a draft PR:
 - ~~JavaDocs are missing from almost everything that is new.~~
 - ~~There is a TODO in `ComponentHolder`~~

What still needs to be done:
 - If this PR will get merged, then the `$ADVENTURE-SUPPORT-SINCE$` placeholders need to be replaced with a proper version. This placeholder is used in JavaDoc `@since` tags.