### PR TITLE
Pass proper (raw) slot to inventory click on drag with one item.

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiListener.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiListener.java
@@ -233,12 +233,12 @@ public class GuiListener implements Listener {
         }
 
         InventoryView view = event.getView();
-        Set<Integer> inventorySlots = event.getInventorySlots();
+        Set<Integer> inventorySlots = event.getRawSlots();
 
         if (inventorySlots.size() > 1) {
             boolean top = false, bottom = false;
 
-            for (int inventorySlot : event.getRawSlots()) {
+            for (int inventorySlot : inventorySlots) {
                 Inventory inventory = view.getInventory(inventorySlot);
 
                 if (view.getTopInventory().equals(inventory)) {


### PR DESCRIPTION
Hello.

[getInventorySlots](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/inventory/InventoryDragEvent.html#getInventorySlots()) returns relative slot index to the clicked inventory, but InventoryClickEvent's constructor consumes raw slot index.
Without this change, dragging a single item in the bottom inventory triggered upper inventory listeners (top inventory panes listeners too!).

https://github.com/stefvanschie/IF/blob/0c9c9d3c4bc3aa1d724e1881b3a3457529b28251/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiListener.java#L265