### PR TITLE
Replace BuildTools and SpecialSource with the paper-nms-maven-plugin

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,6 +24,7 @@ jobs:
           build
           paperclip
           ~/.m2/repository/io/papermc/paper
+          ~/.m2/repository/ca/bkaw/paper-nms
         key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-paperclip
     - name: Download Paperclip jars
       if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Build'
     steps:
-    - name: Cache Paperclip Jars
+    - name: Cache Paper(clip) jars
       id: cache-paperclip-jars
       uses: actions/cache@v2
       with:
@@ -24,9 +24,8 @@ jobs:
           build
           paperclip
           ~/.m2/repository/io/papermc/paper
-          ~/.m2/repository/org/spigotmc
         key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-paperclip
-    - name: Download Paperclip Jars
+    - name: Download Paperclip jars
       if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'
       run: |
         mkdir -p paperclip
@@ -39,7 +38,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Generate 1.14 - 1.16 Paper Jars
+    - name: Generate 1.14 - 1.16 Paper jars
       if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'
       run: |
         cd paperclip/
@@ -49,7 +48,7 @@ jobs:
         java -jar paper-1.16.3.jar
         java -jar paper-1.16.4.jar
         cd ../
-    - name: Install 1.14 - 1.16 Paper Jars
+    - name: Install 1.14 - 1.16 Paper jars
       if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'
       run: |
         cd paperclip/
@@ -59,33 +58,18 @@ jobs:
         mvn install:install-file -Dfile=cache/patched_1.16.3.jar -DgroupId="io.papermc" -DartifactId="paper" -Dversion="1.16.3-R0.1-SNAPSHOT" -Dpackaging="jar"
         mvn install:install-file -Dfile=cache/patched_1.16.4.jar -DgroupId="io.papermc" -DartifactId="paper" -Dversion="1.16.4-R0.1-SNAPSHOT" -Dpackaging="jar"
         cd ../
-    - name: Set up JDK 16
-      uses: actions/setup-java@v1
-      with:
-        java-version: 16
-    - name: Run BuildTools 1.17
-      if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'
-      run: |
-        mkdir -p build
-        cd build/
-        wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar -O BuildTools.jar
-        java -jar BuildTools.jar --rev 1.17 --remapped --disable-java-check
-        java -jar BuildTools.jar --rev 1.17.1 --remapped --disable-java-check
-        cd ../
     - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
         java-version: 17
-    - name: Run BuildTools 1.18
+    - name: Run paper-nms init
       if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'
       run: |
-        mkdir -p build
-        cd build/
-        wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar -O BuildTools.jar
-        java -jar BuildTools.jar --rev 1.18 --remapped --disable-java-check
-        java -jar BuildTools.jar --rev 1.18.1 --remapped --disable-java-check
-        java -jar BuildTools.jar --rev 1.18.2 --remapped --disable-java-check
-        cd ../
+        mvn paper-nms:init -pl nms/1_17_0
+        mvn paper-nms:init -pl nms/1_17_1
+        mvn paper-nms:init -pl nms/1_18_0
+        mvn paper-nms:init -pl nms/1_18_1
+        mvn paper-nms:init -pl nms/1_18_2
     - uses: actions/checkout@v2
       name: Checkout code
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -51,13 +51,11 @@ jobs:
       if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'
       working-directory: paperclip
       run: |
-        cd paperclip/
         mvn install:install-file -Dfile=cache/patched_1.14.4.jar -DgroupId="io.papermc" -DartifactId="paper" -Dversion="1.14.4-R0.1-SNAPSHOT" -Dpackaging="jar"
         mvn install:install-file -Dfile=cache/patched_1.15.2.jar -DgroupId="io.papermc" -DartifactId="paper" -Dversion="1.15.2-R0.1-SNAPSHOT" -Dpackaging="jar"
         mvn install:install-file -Dfile=cache/patched_1.16.1.jar -DgroupId="io.papermc" -DartifactId="paper" -Dversion="1.16.1-R0.1-SNAPSHOT" -Dpackaging="jar"
         mvn install:install-file -Dfile=cache/patched_1.16.3.jar -DgroupId="io.papermc" -DartifactId="paper" -Dversion="1.16.3-R0.1-SNAPSHOT" -Dpackaging="jar"
         mvn install:install-file -Dfile=cache/patched_1.16.4.jar -DgroupId="io.papermc" -DartifactId="paper" -Dversion="1.16.4-R0.1-SNAPSHOT" -Dpackaging="jar"
-        cd ../
     - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -40,16 +40,16 @@ jobs:
         java-version: 11
     - name: Generate 1.14 - 1.16 Paper jars
       if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'
+      working-directory: paperclip
       run: |
-        cd paperclip/
         java -jar paper-1.14.4.jar
         java -jar paper-1.15.2.jar
         java -jar paper-1.16.1.jar
         java -jar paper-1.16.3.jar
         java -jar paper-1.16.4.jar
-        cd ../
     - name: Install 1.14 - 1.16 Paper jars
       if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'
+      working-directory: paperclip
       run: |
         cd paperclip/
         mvn install:install-file -Dfile=cache/patched_1.14.4.jar -DgroupId="io.papermc" -DartifactId="paper" -Dversion="1.14.4-R0.1-SNAPSHOT" -Dpackaging="jar"
@@ -62,6 +62,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 17
+    - uses: actions/checkout@v2
+      name: Checkout code
     - name: Run paper-nms init
       if: steps.cache-paperclip-jars.outputs.cache-hit != 'true'
       run: |
@@ -70,7 +72,5 @@ jobs:
         mvn paper-nms:init -pl nms/1_18_0
         mvn paper-nms:init -pl nms/1_18_1
         mvn paper-nms:init -pl nms/1_18_2
-    - uses: actions/checkout@v2
-      name: Checkout code
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ IF-Test
 *.txt
 dependency-reduced-pom.xml
 *.log
+.paper-nms

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ If you want to build this project from source, run the following:
 
 This will clone this repository to your device. This project relies on NMS, for which the dependencies are not available online. Because of this, you'll need to follow additional steps to obtain all these dependencies locally.
 
-### Installing Paper
-For versions 1.14-1.16, we use Paper. Run the following scripts for each version to install the dependencies locally. Running these commands generate additional files in the folder where you execute them. To ensure that you don't accidentallly overwrite other files, execute this in an empty folder. The files that get created can be deleted afterwards (either after installing a single version or after installing all of them), since they're no longer necessary.
+### Installing Paper manually
+For versions 1.14-1.16, we have to manually install Paper. Run the following scripts for each version to install the dependencies locally. Running these commands generate additional files in the folder where you execute them. To ensure that you don't accidentallly overwrite other files, execute this in an empty folder. The files that get created can be deleted afterwards (either after installing a single version or after installing all of them), since they're no longer necessary.
 
 #### 1.14.4
 ```
@@ -124,15 +124,14 @@ java -jar paper-1.16.4.jar
 mvn install:install-file -Dfile=cache/patched_1.16.4.jar -DgroupId="io.papermc" -DartifactId="paper" -Dversion="1.16.4-R0.1-SNAPSHOT" -Dpackaging="jar"
 ```
 
-### Installing Spigot
-For versions 1.17-1.18, we use Spigot. To install these versions locally, we use Spigot's BuildTools system. Using BuildTools will create additional files, so we recommend running the following in an empty folder. The files can be deleted afterwards.
+### Installing Paper via the maven plugin
+For versions 1.17-1.18, we use Paper via the [paper-nms-maven-plugin](https://github.com/Alvinn8/paper-nms-maven-plugin). To install these versions locally, we must run a few maven commands. These commands should be ran in the root directory of the project.
 ```
-wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar -O BuildTools.jar
-java -jar BuildTools.jar --rev 1.17 --remapped --disable-java-check
-java -jar BuildTools.jar --rev 1.17.1 --remapped --disable-java-check
-java -jar BuildTools.jar --rev 1.18 --remapped --disable-java-check
-java -jar BuildTools.jar --rev 1.18.1 --remapped --disable-java-check
-java -jar BuildTools.jar --rev 1.18.2 --remapped --disable-java-check
+mvn paper-nms:init -pl nms/1_17_0
+mvn paper-nms:init -pl nms/1_17_1
+mvn paper-nms:init -pl nms/1_18_0
+mvn paper-nms:init -pl nms/1_18_1
+mvn paper-nms:init -pl nms/1_18_2
 ```
 
 Your environment is now set up correctly. To create a build, run the following inside the root folder of the project.

--- a/nms/1_17_0/pom.xml
+++ b/nms/1_17_0/pom.xml
@@ -24,10 +24,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
-            <classifier>remapped-mojang</classifier>
+            <groupId>ca.bkaw</groupId>
+            <artifactId>paper-nms</artifactId>
+            <version>1.17-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -35,38 +34,26 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>net.md-5</groupId>
-                <artifactId>specialsource-maven-plugin</artifactId>
-                <version>1.2.4</version>
+                <groupId>ca.bkaw</groupId>
+                <artifactId>paper-nms-maven-plugin</artifactId>
+                <version>1.2-SNAPSHOT</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>remap</goal>
                         </goals>
-                        <id>remap-obf</id>
-                        <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.17-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
-                            <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.17-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
-                            <remappedArtifactAttached>true</remappedArtifactAttached>
-                            <remappedClassifierName>remapped-obf</remappedClassifierName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>remap</goal>
-                        </goals>
-                        <id>remap-spigot</id>
-                        <configuration>
-                            <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.17-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.17-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bytecode.space</id>
+            <url>https://repo.bytecode.space/repository/maven-public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>

--- a/nms/1_17_0/pom.xml
+++ b/nms/1_17_0/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>ca.bkaw</groupId>
                 <artifactId>paper-nms-maven-plugin</artifactId>
-                <version>1.2-SNAPSHOT</version>
+                <version>1.2</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>

--- a/nms/1_17_1/pom.xml
+++ b/nms/1_17_1/pom.xml
@@ -24,10 +24,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.17.1-R0.1-SNAPSHOT</version>
-            <classifier>remapped-mojang</classifier>
+            <groupId>ca.bkaw</groupId>
+            <artifactId>paper-nms</artifactId>
+            <version>1.17.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -35,39 +34,26 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>net.md-5</groupId>
-                <artifactId>specialsource-maven-plugin</artifactId>
-                <version>1.2.4</version>
+                <groupId>ca.bkaw</groupId>
+                <artifactId>paper-nms-maven-plugin</artifactId>
+                <version>1.2-SNAPSHOT</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>remap</goal>
                         </goals>
-                        <id>remap-obf</id>
-                        <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.17.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
-                            <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.17.1-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
-                            <remappedArtifactAttached>true</remappedArtifactAttached>
-                            <remappedClassifierName>remapped-obf</remappedClassifierName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>remap</goal>
-                        </goals>
-                        <id>remap-spigot</id>
-                        <configuration>
-                            <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.17.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.17.1-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bytecode.space</id>
+            <url>https://repo.bytecode.space/repository/maven-public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/nms/1_17_1/pom.xml
+++ b/nms/1_17_1/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>ca.bkaw</groupId>
                 <artifactId>paper-nms-maven-plugin</artifactId>
-                <version>1.2-SNAPSHOT</version>
+                <version>1.2</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>

--- a/nms/1_18_0/pom.xml
+++ b/nms/1_18_0/pom.xml
@@ -24,10 +24,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.18-R0.1-SNAPSHOT</version>
-            <classifier>remapped-mojang</classifier>
+            <groupId>ca.bkaw</groupId>
+            <artifactId>paper-nms</artifactId>
+            <version>1.18-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -35,39 +34,26 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>net.md-5</groupId>
-                <artifactId>specialsource-maven-plugin</artifactId>
-                <version>1.2.4</version>
+                <groupId>ca.bkaw</groupId>
+                <artifactId>paper-nms-maven-plugin</artifactId>
+                <version>1.2-SNAPSHOT</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>remap</goal>
                         </goals>
-                        <id>remap-obf</id>
-                        <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.18-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
-                            <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.18-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
-                            <remappedArtifactAttached>true</remappedArtifactAttached>
-                            <remappedClassifierName>remapped-obf</remappedClassifierName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>remap</goal>
-                        </goals>
-                        <id>remap-spigot</id>
-                        <configuration>
-                            <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.18-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.18-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bytecode.space</id>
+            <url>https://repo.bytecode.space/repository/maven-public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/nms/1_18_0/pom.xml
+++ b/nms/1_18_0/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>ca.bkaw</groupId>
                 <artifactId>paper-nms-maven-plugin</artifactId>
-                <version>1.2-SNAPSHOT</version>
+                <version>1.2</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>

--- a/nms/1_18_1/pom.xml
+++ b/nms/1_18_1/pom.xml
@@ -24,10 +24,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.18-R0.1-SNAPSHOT</version>
-            <classifier>remapped-mojang</classifier>
+            <groupId>ca.bkaw</groupId>
+            <artifactId>paper-nms</artifactId>
+            <version>1.18.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -35,39 +34,26 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>net.md-5</groupId>
-                <artifactId>specialsource-maven-plugin</artifactId>
-                <version>1.2.4</version>
+                <groupId>ca.bkaw</groupId>
+                <artifactId>paper-nms-maven-plugin</artifactId>
+                <version>1.2-SNAPSHOT</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>remap</goal>
                         </goals>
-                        <id>remap-obf</id>
-                        <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.18.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
-                            <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.18.1-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
-                            <remappedArtifactAttached>true</remappedArtifactAttached>
-                            <remappedClassifierName>remapped-obf</remappedClassifierName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>remap</goal>
-                        </goals>
-                        <id>remap-spigot</id>
-                        <configuration>
-                            <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.18.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.18.1-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bytecode.space</id>
+            <url>https://repo.bytecode.space/repository/maven-public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/nms/1_18_1/pom.xml
+++ b/nms/1_18_1/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>ca.bkaw</groupId>
                 <artifactId>paper-nms-maven-plugin</artifactId>
-                <version>1.2-SNAPSHOT</version>
+                <version>1.2</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>

--- a/nms/1_18_2/pom.xml
+++ b/nms/1_18_2/pom.xml
@@ -24,10 +24,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.18.2-R0.1-SNAPSHOT</version>
-            <classifier>remapped-mojang</classifier>
+            <groupId>ca.bkaw</groupId>
+            <artifactId>paper-nms</artifactId>
+            <version>1.18.2-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -35,39 +34,26 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>net.md-5</groupId>
-                <artifactId>specialsource-maven-plugin</artifactId>
-                <version>1.2.4</version>
+                <groupId>ca.bkaw</groupId>
+                <artifactId>paper-nms-maven-plugin</artifactId>
+                <version>1.2-SNAPSHOT</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>remap</goal>
                         </goals>
-                        <id>remap-obf</id>
-                        <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.18.2-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
-                            <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.18.2-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
-                            <remappedArtifactAttached>true</remappedArtifactAttached>
-                            <remappedClassifierName>remapped-obf</remappedClassifierName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>remap</goal>
-                        </goals>
-                        <id>remap-spigot</id>
-                        <configuration>
-                            <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.18.2-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.18.2-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bytecode.space</id>
+            <url>https://repo.bytecode.space/repository/maven-public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/nms/1_18_2/pom.xml
+++ b/nms/1_18_2/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>ca.bkaw</groupId>
                 <artifactId>paper-nms-maven-plugin</artifactId>
-                <version>1.2-SNAPSHOT</version>
+                <version>1.2</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>


### PR DESCRIPTION
Replaces BuildTools/SpecialSource with the (unofficial) [paper-nms-maven-plugin](https://github.com/Alvinn8/paper-nms-maven-plugin), which should be easier to use and faster.