### PR TITLE
Fixed a typo with dirty rows

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
@@ -81,7 +81,7 @@ public class ChestGui extends NamedGui implements MergedGui, InventoryBased {
     public void show(@NotNull HumanEntity humanEntity) {
         if (isDirty() || dirtyRows) {
             this.inventory = createInventory();
-            this.dirtyRows = true;
+            this.dirtyRows = false;
 
             markChanges();
         }


### PR DESCRIPTION
When then new inventory instance is created the dirty row value is set to true instead of false, which is causing an endless loop of creating a new inventory instance once the rows or title changed once.

This PR aims to correct the problem.