### PR TITLE
Fix invisible OutlinePane items breaking everything after it

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
@@ -236,10 +236,9 @@ public class OutlinePane extends Pane implements Flippable, Orientable, Rotatabl
                         int finalColumn = slot.getX(maxLength) + x + paneOffsetX;
 
                         GuiItem item = items[index];
-                        if (!item.isVisible()) {
-                            continue;
+                        if (item.isVisible()) {
+                            inventoryComponent.setItem(item, finalColumn, finalRow);
                         }
-                        inventoryComponent.setItem(item, finalColumn, finalRow);
                     }
                 }
 


### PR DESCRIPTION
PR #247 was flawed and caused items after an invisible item to not show as well, this PR fixes said problem.
This also addresses the second problem of #276 