### PR TITLE
Fix inverted logic for XML onClick bindings

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
@@ -522,8 +522,8 @@ public abstract class Pane {
                             Object attribute = properties.get(i);
 
                             if (!(parameterTypes[1 + i].isPrimitive() &&
-                                    Primitives.unwrap(attribute.getClass()).isAssignableFrom(parameterTypes[1 + i])) &&
-                                    !attribute.getClass().isAssignableFrom(parameterTypes[1 + i]))
+                                    parameterTypes[1 + i].isAssignableFrom(Primitives.unwrap(attribute.getClass()))) &&
+                                    !parameterTypes[1 + i].isAssignableFrom(attribute.getClass()))
                                 correct = false;
                         }
 


### PR DESCRIPTION
The code should check that the property is assignable to the parameter, not that the parameter is assignable to the property.