### PR TITLE
Pass owning plugin down to panes

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/InventoryComponent.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/InventoryComponent.java
@@ -7,6 +7,8 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -300,6 +302,19 @@ public class InventoryComponent {
      * @since 0.8.0
      */
     public void load(@NotNull Object instance, @NotNull Element element) {
+        load(instance, element, JavaPlugin.getProvidingPlugin(InventoryComponent.class));
+    }
+
+    /**
+     * Loads the provided element's child panes onto this component. If the element contains any child panes, this will
+     * mutate this component.
+     *
+     * @param instance the instance to apply field and method references on
+     * @param element the element to load
+     * @param plugin the plugin to load the panes with
+     * @since 0.10.11
+     */
+    public void load(@NotNull Object instance, @NotNull Element element, @NotNull Plugin plugin) {
         NodeList childNodes = element.getChildNodes();
 
         for (int innerIndex = 0; innerIndex < childNodes.getLength(); innerIndex++) {
@@ -309,7 +324,7 @@ public class InventoryComponent {
                 continue;
             }
 
-            addPane(Gui.loadPane(instance, innerItem));
+            addPane(Gui.loadPane(instance, innerItem, plugin));
         }
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/type/ChestGui.java
@@ -331,9 +331,9 @@ public class ChestGui extends NamedGui implements MergedGui, InventoryBased {
             InventoryComponent inventoryComponent = chestGui.getInventoryComponent();
 
             if (componentElement.getTagName().equalsIgnoreCase("component")) {
-                inventoryComponent.load(instance, componentElement);
+                inventoryComponent.load(instance, componentElement, plugin);
             } else {
-                inventoryComponent.load(instance, element);
+                inventoryComponent.load(instance, element, plugin);
             }
 
             break;


### PR DESCRIPTION
This PR corrects behaviour of passing own plugin instance. Currently, when we pass instance to `ChestGui#load`, it's not passed to panes loaded from XML which is causing issues with new Paper's plugin system (basically JavaPlugin#getProvidingPlugin(Class) won't work in that new system in short).

Stack trace I was getting:
```
Caused by: java.lang.IllegalArgumentException: class com.github.stefvanschie.inventoryframework.gui.type.util.Gui is not provided by a interface io.papermc.paper.plugin.provider.classloader.ConfiguredPluginClassLoader
	at org.bukkit.plugin.java.JavaPlugin.getProvidingPlugin(JavaPlugin.java:451) ~[paper-api-1.20.1-R0.1-SNAPSHOT.jar:?]
	at com.github.stefvanschie.inventoryframework.gui.type.util.Gui.loadPane(Gui.java:703) ~[?:?]
	at com.github.stefvanschie.inventoryframework.gui.InventoryComponent.load(InventoryComponent.java:312) ~[?:?]
	at com.github.stefvanschie.inventoryframework.gui.type.ChestGui.load(ChestGui.java:336) ~[?:?]
	at com.github.stefvanschie.inventoryframework.gui.type.ChestGui.load(ChestGui.java:279) ~[?:?]
```