### PR TITLE
Use PlayerProfile instead of GameProfile to set skull texture

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/util/SkullUtil.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/util/SkullUtil.java
@@ -5,6 +5,7 @@ import com.mojang.authlib.properties.Property;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
@@ -37,19 +38,44 @@ public final class SkullUtil {
     @NotNull
     public static ItemStack getSkull(@NotNull String id) {
         ItemStack item = new ItemStack(Material.PLAYER_HEAD);
-        ItemMeta itemMeta = Objects.requireNonNull(item.getItemMeta());
+        SkullMeta itemMeta = (SkullMeta) Objects.requireNonNull(item.getItemMeta());
         setSkull(itemMeta, id);
         item.setItemMeta(itemMeta);
         return item;
     }
 
     /**
-     * Sets the skull of an existing {@link ItemMeta} from the specified id.
+     * Sets the skull of an existing {@link SkullMeta} from the specified id.
      * The id is the value from the textures.minecraft.net website after the last '/' character.
      *
      * @param meta the meta to change
      * @param id the skull id
      */
+    public static void setSkull(@NotNull SkullMeta meta, @NotNull String id) {
+        GameProfile profile = new GameProfile(UUID.randomUUID(), "");
+        byte[] encodedData = Base64.getEncoder().encode(String.format("{textures:{SKIN:{url:\"%s\"}}}",
+                "http://textures.minecraft.net/texture/" + id).getBytes());
+        profile.getProperties().put("textures", new Property("textures", new String(encodedData)));
+
+        try {
+            Field profileField = meta.getClass().getDeclaredField("profile");
+            profileField.setAccessible(true);
+            profileField.set(meta, profile);
+        } catch (NoSuchFieldException | SecurityException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the skull of an existing {@link ItemMeta} from the specified id.
+     * The id is the value from the textures.minecraft.net website after the last '/' character.
+     *
+     * @deprecated This method is deprecated. Use {@link #setSkull(SkullMeta, String)} instead.
+     *
+     * @param meta the meta to change
+     * @param id the skull id
+     */
+    @Deprecated
     public static void setSkull(@NotNull ItemMeta meta, @NotNull String id) {
         GameProfile profile = new GameProfile(UUID.randomUUID(), null);
         byte[] encodedData = Base64.getEncoder().encode(String.format("{textures:{SKIN:{url:\"%s\"}}}",


### PR DESCRIPTION
I am making this pull request because I was having an issue with the Label Pane. The problem was as follows: when trying to create a label pane, I was getting the following error:
```
java.lang.ExceptionInInitializerError: null
	at io.github.vicen621.advanceduhc.scenarios.ScenarioManagerImpl.lambda$getScenInventory$23(ScenarioManagerImpl.java:332) ~[advanced-uhc-plugin-1.2.0.jar:?]
	at org.bukkit.craftbukkit.v1_20_R2.scheduler.CraftTask.run(CraftTask.java:101) ~[paper-1.20.2.jar:git-Paper-260]
	at org.bukkit.craftbukkit.v1_20_R2.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[paper-1.20.2.jar:git-Paper-260]
	at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[paper-1.20.2.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.NullPointerException: Profile name must not be null
	at java.util.Objects.requireNonNull(Objects.java:235) ~[?:?]
	at com.mojang.authlib.GameProfile.<init>(GameProfile.java:31) ~[authlib-5.0.47.jar:?]
	at io.github.vicen621.advanceduhc.libs.inventoryframework.util.SkullUtil.setSkull(SkullUtil.java:54) ~[advanced-uhc-plugin-1.2.0.jar:?]
	at io.github.vicen621.advanceduhc.libs.inventoryframework.util.SkullUtil.getSkull(SkullUtil.java:41) ~[advanced-uhc-plugin-1.2.0.jar:?]
	at io.github.vicen621.advanceduhc.libs.inventoryframework.font.CSVFont.lambda$new$1(CSVFont.java:46) ~[advanced-uhc-plugin-1.2.0.jar:?]
	at java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:180) ~[?:?]
	at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at io.github.vicen621.advanceduhc.libs.inventoryframework.font.CSVFont.<init>(CSVFont.java:46) ~[advanced-uhc-plugin-1.2.0.jar:?]
	at io.github.vicen621.advanceduhc.libs.inventoryframework.font.util.Font.<clinit>(Font.java:29) ~[advanced-uhc-plugin-1.2.0.jar:?]
	... 7 more
```
Upon investigating the cause, it seems that in the new versions, GameProfiles cannot be created with a null name, so the first thing I did was create the GameProfile with an empty string. This worked, but I still got the following message:
```
Found inconsistent skull meta, this should normally not happen and is not a Bukkit / Spigot issue, but one from a plugin you are using.
Bukkit will attempt to fix it this time for you, but may not be able to do this every time.
If you see this message after typing a command from a plugin, please report this to the plugin developer, they should use the api instead of relying on reflection (and doing it the wrong way).
```
So, after doing some research, I found that the way to resolve it was by using PlayerProfiles. This fixes the error I was experiencing with the labels.

Feel free to reach out for any questions. Thank you in advance!