### PR TITLE
Get slotted items

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/StaticPane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/StaticPane.java
@@ -328,11 +328,41 @@ public class StaticPane extends Pane implements Flippable, Rotatable {
 		this.fillWith(itemStack, null);
 	}
 
+    /**
+     * Gets a gui item from the specific spot in the pane by x and y coordinates
+     *
+     * @param x         the x coordinate of the position of the item
+     * @param y         the y coordinate of the position of the item
+     * @since TODO: __VERSION__
+     */
+    public GuiItem getItem(int x, int y) {
+        return getItem(Slot.fromXY(x, y));
+    }
+
+    /**
+     * Gets the specified item from the pane by the slot
+     *
+     * @param slot      the slot of the item
+     * @since TODO: __VERSION__
+     */
+    public GuiItem getItem(Slot slot) {
+        return items.get(slot);
+    }
+
 	@NotNull
 	@Override
 	public Collection<GuiItem> getItems() {
 		return items.values();
 	}
+
+    /**
+     * Get the GUI items with their slots
+     * @return Map<Slot, GuiItem>
+     * @since TODO: __VERSION__
+     */
+    public @NotNull Map<Slot, GuiItem> getSlottedItems() {
+        return items;
+    }
 
     @Override
     public void clear() {


### PR DESCRIPTION
Ability to retrieve GuiItems with their slots and get items based on coordinates or slot

This has been a pull request in the past but this one includes the documentation

@stefvanschie I've added TODO's for adding the version numbers.