### PR TITLE
Removed `getInventory().clear()` from onInventoryClose

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiListener.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiListener.java
@@ -354,8 +354,6 @@ public class GuiListener implements Listener {
         if (!gui.isUpdating()) {
             gui.callOnClose(event);
 
-            event.getInventory().clear(); //clear inventory to prevent items being put back
-
             gui.getHumanEntityCache().restoreAndForget(humanEntity);
 
             if (gui.getViewerCount() == 1) {


### PR DESCRIPTION
Removed `getInventory().clear()` as some users don't want this functionality, but there is no way to opt-out of this, so it's better to remove it and give users the option to do it themselves if needed.

Alternative Solution:
Add a way to opt-out from this, or only clear the inventory after the callbacks have been called, so if needed, callbacks can use the inventory without it being empty