### PR TITLE
Avoid saving a GuiItem's UUID if it doesn't have an action

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
@@ -90,7 +90,7 @@ public class GuiItem {
      * @since 0.10.8
      */
     public GuiItem(@NotNull ItemStack item, @NotNull Plugin plugin) {
-        this(item, event -> {}, plugin);
+        this(item, null, plugin);
     }
 
     /**
@@ -109,7 +109,7 @@ public class GuiItem {
      * @param item the item stack
      */
     public GuiItem(@NotNull ItemStack item) {
-        this(item, event -> {});
+        this(item, (Consumer<InventoryClickEvent>) null);
     }
 
     /**
@@ -153,7 +153,7 @@ public class GuiItem {
         guiItem.properties = new ArrayList<>(properties);
         ItemMeta meta = guiItem.item.getItemMeta();
 
-        if (meta != null) {
+        if (meta != null && action != null) {
             meta.getPersistentDataContainer().set(keyUUID, UUIDTagType.INSTANCE, guiItem.uuid);
             guiItem.item.setItemMeta(meta);
         }
@@ -185,14 +185,14 @@ public class GuiItem {
 
     /**
      * Sets the internal UUID of this gui item onto the underlying item. Previously set UUID will be overwritten by the
-     * current UUID. If the underlying item does not have an item meta, this method will silently do nothing.
+     * current UUID. If the underlying item does not have an item meta or a defined action, this method will silently do nothing.
      *
      * @since 0.9.3
      */
     public void applyUUID() {
         ItemMeta meta = item.getItemMeta();
 
-        if (meta != null) {
+        if (meta != null && action != null) {
             meta.getPersistentDataContainer().set(this.keyUUID, UUIDTagType.INSTANCE, uuid);
             item.setItemMeta(meta);
         }


### PR DESCRIPTION
Title says it all.

This is useful when items don't have an action _at all_, for example in a GUI in which a player can grab items and put them in their inventory. Having the UUID in the item's data prevents it from stacking with other items of the same type.