### PR TITLE
Allow backward/forward button always be visible

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PagingButtons.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PagingButtons.java
@@ -346,7 +346,7 @@ public class PagingButtons extends Pane {
     }
 
     /**
-     * Allow to always keep the backward & forward buttons visible when on the first and last page
+     * Allow to always keep the backward and forward buttons visible when on the first and last page
      *
      * @param visible Whether to keep the buttons visible
      * @since 0.11.6


### PR DESCRIPTION
Added an option to keep the Back and Forward buttons always visible, even on the first and last pages.
I personally like having them always visible, so I figured others might appreciate the option too.

The page-switching code is now wrapped in a try-catch block, ensuring that no errors are shown during navigation, for example when clicking "Previous" while on page 1.