### PR TITLE
fix: remove unsupported version exception on version check

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/util/version/Version.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/util/version/Version.java
@@ -275,7 +275,7 @@ public enum Version {
     }
 
     /**
-     * Gets the version currently being used. If the used version is not supported, an
+     * Gets the version currently being used. If the used version is not supported,
      * the latest will be used.
      *
      * @return the version of the current instance


### PR DESCRIPTION
This PR removes the Unsupported Version Exeption from the Version check.

Currently, the Exeption destroys every inventory when IF is not up-to-date. Players can get Creative or OP Items simply by removing them from a inventory.

I think this is **not** a final solution, but a temporary fix. Please review and give Feedback or suggest another solution for this problem.
 
**This is untested.**