### PR TITLE
Make GuiItem constructor with NamespacedKey param public

### DIFF
--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
@@ -150,7 +150,7 @@ public class GuiItem {
      * @param key the key to identify this item with
      * @since 0.10.10
      */
-    private GuiItem(@NotNull ItemStack item, @Nullable Consumer<? super InventoryClickEvent> action,
+    public GuiItem(@NotNull ItemStack item, @Nullable Consumer<? super InventoryClickEvent> action,
                     @NotNull Logger logger, @NotNull NamespacedKey key) {
         this.logger = logger;
         this.keyUUID = key;


### PR DESCRIPTION
Hey. 

Could we make this constructor public? 

I have a pretty good use in my project to change the keys of the namespaced keys. It works completely fine with custom defined keys. 

I do not see any reason for this constructor to be private