### PR TITLE
Introduce GuiClickEvent and getItem(Slot slot)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -102,7 +102,7 @@ jobs:
         cd ..
 
         cd Spigot
-        git checkout fb8fb722a327a2f9f097f2ded700ac5de8157408
+        git checkout fb8fb722a327a2f9f097f2ded700ac5de8157408w
         cd ..
 
         cd BuildData

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -102,7 +102,7 @@ jobs:
         cd ..
 
         cd Spigot
-        git checkout fb8fb722a327a2f9f097f2ded700ac5de8157408w
+        git checkout fb8fb722a327a2f9f097f2ded700ac5de8157408
         cd ..
 
         cd BuildData

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiClickEvent.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiClickEvent.java
@@ -1,0 +1,34 @@
+package com.github.stefvanschie.inventoryframework.gui;
+
+import com.github.stefvanschie.inventoryframework.pane.util.Slot;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class GuiClickEvent {
+
+    @NotNull
+    private final InventoryClickEvent event;
+
+    /**
+     * The slot that was clicked, expressed relative to the top-left corner of the pane that received the click.
+     * For example, if a pane starts at column 3, row 1 of the inventory and the player clicks column 3, row 1,
+     * this slot will be (0, 0).
+     */
+    @NotNull
+    private final Slot relativeSlot;
+
+    public GuiClickEvent(@NotNull InventoryClickEvent event, @NotNull Slot relativeSlot) {
+        this.event = event;
+        this.relativeSlot = relativeSlot;
+    }
+
+    @NotNull
+    public InventoryClickEvent getClickEvent() {
+        return event;
+    }
+
+    @NotNull
+    public Slot getRelativeSlot() {
+        return relativeSlot;
+    }
+}

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
@@ -14,6 +14,7 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -70,7 +71,7 @@ public class GuiItem {
      * An action for the inventory
      */
     @Nullable
-    private Consumer<? super InventoryClickEvent> action;
+    private Consumer<? super GuiClickEvent> action;
     
     /**
      * List of item's properties
@@ -104,7 +105,7 @@ public class GuiItem {
      * @see #GuiItem(ItemStack, Consumer)
      * @since 0.10.8
      */
-    public GuiItem(@NotNull ItemStack item, @Nullable Consumer<? super InventoryClickEvent> action,
+    public GuiItem(@NotNull ItemStack item, @Nullable Consumer<? super GuiClickEvent> action,
                    @NotNull Plugin plugin) {
         this(item, action, plugin.getLogger(), new NamespacedKey(plugin, "IF-uuid"));
     }
@@ -118,7 +119,7 @@ public class GuiItem {
      * @since 0.10.8
      */
     public GuiItem(@NotNull ItemStack item, @NotNull Plugin plugin) {
-        this(item, event -> {}, plugin);
+        this(item, (Consumer<? super GuiClickEvent>) null, plugin);
     }
 
     /**
@@ -127,7 +128,7 @@ public class GuiItem {
      * @param item the item stack
      * @param action the action called whenever an interaction with this item happens
      */
-    public GuiItem(@NotNull ItemStack item, @Nullable Consumer<? super InventoryClickEvent> action) {
+    public GuiItem(@NotNull ItemStack item, @Nullable Consumer<? super GuiClickEvent> action) {
         this(item, action, JavaPlugin.getProvidingPlugin(GuiItem.class));
     }
 
@@ -137,7 +138,7 @@ public class GuiItem {
      * @param item the item stack
      */
     public GuiItem(@NotNull ItemStack item) {
-        this(item, event -> {});
+        this(item, (Consumer<? super GuiClickEvent>) null);
     }
 
     /**
@@ -150,7 +151,7 @@ public class GuiItem {
      * @param key the key to identify this item with
      * @since 0.10.10
      */
-    private GuiItem(@NotNull ItemStack item, @Nullable Consumer<? super InventoryClickEvent> action,
+    private GuiItem(@NotNull ItemStack item, @Nullable Consumer<? super GuiClickEvent> action,
                     @NotNull Logger logger, @NotNull NamespacedKey key) {
         this.logger = logger;
         this.keyUUID = key;
@@ -188,7 +189,7 @@ public class GuiItem {
      * @param event the event to handle
      * @since 0.6.0
      */
-    public void callAction(@NotNull InventoryClickEvent event) {
+    public void callAction(@NotNull GuiClickEvent event) {
         if (action == null) {
             return;
         }
@@ -197,8 +198,8 @@ public class GuiItem {
             action.accept(event);
         } catch (Throwable t) {
             this.logger.log(Level.SEVERE, "Exception while handling click event in inventory '"
-                    + InventoryViewUtil.getInstance().getTitle(event.getView()) + "', slot=" + event.getSlot() +
-                    ", item=" + item.getType(), t);
+                    + InventoryViewUtil.getInstance().getTitle(event.getClickEvent().getView()) + "', slot="
+                    + event.getClickEvent().getSlot() + ", item=" + item.getType(), t);
         }
     }
 
@@ -233,7 +234,7 @@ public class GuiItem {
      * @param action the action of this item
      * @since 0.7.1
      */
-    public void setAction(@NotNull Consumer<InventoryClickEvent> action) {
+    public void setAction(@NotNull Consumer<GuiClickEvent> action) {
         this.action = action;
     }
     
@@ -481,7 +482,7 @@ public class GuiItem {
             }
         }
 
-        Consumer<InventoryClickEvent> action = null;
+        Consumer<InventoryClickEvent> rawAction = null;
 
         if (element.hasAttribute("onClick")) {
             String methodName = element.getAttribute("onClick");
@@ -496,9 +497,8 @@ public class GuiItem {
                 Class<?>[] parameterTypes = method.getParameterTypes();
 
                 if (parameterCount == 0) {
-                    action = event -> {
+                    rawAction = event -> {
                         try {
-                            //because reflection with lambdas is stupid
                             method.setAccessible(true);
                             method.invoke(instance);
                         } catch (IllegalAccessException | InvocationTargetException exception) {
@@ -508,9 +508,8 @@ public class GuiItem {
                     found = true;
                 } else if (parameterTypes[0].isAssignableFrom(InventoryClickEvent.class)) {
                     if (parameterCount == 1) {
-                        action = event -> {
+                        rawAction = event -> {
                             try {
-                                //because reflection with lambdas is stupid
                                 method.setAccessible(true);
                                 method.invoke(instance, event);
                             } catch (IllegalAccessException | InvocationTargetException exception) {
@@ -531,16 +530,13 @@ public class GuiItem {
                         }
 
                         if (correct) {
-                            action = event -> {
+                            rawAction = event -> {
                                 try {
-                                    //don't ask me why we need to do this, just roll with it (actually I do know why, but it's stupid)
                                     properties.add(0, event);
 
-                                    //because reflection with lambdas is stupid
                                     method.setAccessible(true);
                                     method.invoke(instance, properties.toArray(new Object[0]));
 
-                                    //since we'll append the event to the list next time again, we need to remove it here again
                                     properties.remove(0);
                                 } catch (IllegalAccessException | InvocationTargetException exception) {
                                     throw new XMLReflectionException(exception);
@@ -558,6 +554,8 @@ public class GuiItem {
                 throw new XMLLoadException("Specified method could not be found");
             }
         }
+
+        Consumer<GuiClickEvent> action = rawAction == null ? null : e -> rawAction.accept(e.getClickEvent());
 
         GuiItem item = new GuiItem(itemStack, action, plugin);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
@@ -15,7 +15,6 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
 import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
-import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -182,7 +181,7 @@ public class GuiItem {
     }
 
     /**
-     * Calls the handler of the {@link InventoryClickEvent}
+     * Calls the handler of the {@link GuiClickEvent}
      * if such a handler was specified in the constructor.
      * Catches and logs all exceptions the handler might throw.
      *
@@ -482,7 +481,7 @@ public class GuiItem {
             }
         }
 
-        Consumer<InventoryClickEvent> rawAction = null;
+        Consumer<GuiClickEvent> action = null;
 
         if (element.hasAttribute("onClick")) {
             String methodName = element.getAttribute("onClick");
@@ -497,7 +496,7 @@ public class GuiItem {
                 Class<?>[] parameterTypes = method.getParameterTypes();
 
                 if (parameterCount == 0) {
-                    rawAction = event -> {
+                    action = event -> {
                         try {
                             method.setAccessible(true);
                             method.invoke(instance);
@@ -506,9 +505,9 @@ public class GuiItem {
                         }
                     };
                     found = true;
-                } else if (parameterTypes[0].isAssignableFrom(InventoryClickEvent.class)) {
+                } else if (parameterTypes[0].isAssignableFrom(GuiClickEvent.class)) {
                     if (parameterCount == 1) {
-                        rawAction = event -> {
+                        action = event -> {
                             try {
                                 method.setAccessible(true);
                                 method.invoke(instance, event);
@@ -530,7 +529,7 @@ public class GuiItem {
                         }
 
                         if (correct) {
-                            rawAction = event -> {
+                            action = event -> {
                                 try {
                                     properties.add(0, event);
 
@@ -554,8 +553,6 @@ public class GuiItem {
                 throw new XMLLoadException("Specified method could not be found");
             }
         }
-
-        Consumer<GuiClickEvent> action = rawAction == null ? null : e -> rawAction.accept(e.getClickEvent());
 
         GuiItem item = new GuiItem(itemStack, action, plugin);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/gui/GuiItem.java
@@ -333,7 +333,6 @@ public class GuiItem {
             throw new XMLLoadException("Can't find material for '" + id + "'");
         }
 
-        boolean hasDamage = element.hasAttribute("damage");
         int amount = 1;
 
         if (element.hasAttribute("amount")) {
@@ -348,7 +347,7 @@ public class GuiItem {
 
         if (element.hasAttribute("damage")) {
             try {
-                amount = Short.parseShort(element.getAttribute("damage"));
+                damage = Short.parseShort(element.getAttribute("damage"));
             } catch (NumberFormatException exception) {
                 throw new XMLLoadException("Damage attribute is not a short", exception);
             }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/MasonryPane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/MasonryPane.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.inventoryframework.gui.GuiItem;
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.pane.util.GuiItemContainer;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
@@ -162,7 +163,7 @@ public class MasonryPane extends Pane implements Orientable {
             return false;
         }
 
-        callOnClick(event);
+        callOnClick(new GuiClickEvent(event, slot));
 
         boolean success = false;
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/MasonryPane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/MasonryPane.java
@@ -165,6 +165,10 @@ public class MasonryPane extends Pane implements Orientable {
 
         callOnClick(new GuiClickEvent(event, slot));
 
+        if (this.cachedPositions == null) {
+            return false;
+        }
+
         boolean success = false;
 
         for (int index = 0; index < this.panes.size(); index++) {

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
@@ -9,11 +9,13 @@ import com.github.stefvanschie.inventoryframework.pane.util.Mask;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
 import com.github.stefvanschie.inventoryframework.util.GeometryUtil;
 import org.bukkit.Material;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -241,7 +243,7 @@ public class OutlinePane extends Pane implements Flippable, Orientable, Rotatabl
             return false;
         }
 
-        callOnClick(event);
+        callOnClick(new GuiClickEvent(event, slot));
 
         ItemStack itemStack = event.getCurrentItem();
 
@@ -255,7 +257,7 @@ public class OutlinePane extends Pane implements Flippable, Orientable, Rotatabl
             return false;
         }
 
-        item.callAction(event);
+        item.callAction(new GuiClickEvent(event, slot));
 
         return true;
     }
@@ -450,6 +452,19 @@ public class OutlinePane extends Pane implements Flippable, Orientable, Rotatabl
     @Override
     public List<GuiItem> getItems() {
         return items;
+    }
+
+    @Nullable
+    @Contract(pure = true)
+    public GuiItem getGuiItem(@NotNull Slot slot) {
+        int x = slot.getX(getLength());
+        int y = slot.getY(getLength());
+
+        if (x < 0 || x >= getLength() || y < 0 || y >= getHeight()) {
+            return null;
+        }
+
+        return display().getItem(x, y);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/OutlinePane.java
@@ -122,12 +122,14 @@ public class OutlinePane extends Pane implements Flippable, Orientable, Rotatabl
         if (getOrientation() == Orientation.HORIZONTAL) {
             size = getHeight();
         } else if (getOrientation() == Orientation.VERTICAL) {
-            size = getHeight();
+            size = getLength();
         } else {
             throw new IllegalStateException("Unknown orientation '" + getOrientation() + "'");
         }
 
-        for (int vectorIndex = 0; vectorIndex < size && getItems().size() > itemIndex; vectorIndex++) {
+        List<GuiItem> allItems = getItems();
+
+        for (int vectorIndex = 0; vectorIndex < size && allItems.size() > itemIndex; vectorIndex++) {
             boolean[] maskLine;
 
             if (getOrientation() == Orientation.HORIZONTAL) {
@@ -151,18 +153,18 @@ public class OutlinePane extends Pane implements Flippable, Orientable, Rotatabl
             if (doesRepeat()) {
                 items = new GuiItem[enabled];
             } else {
-                int remainingPositions = gapCount + (getItems().size() - itemIndex - 1) * (getGap() + 1) + 1;
+                int remainingPositions = gapCount + (allItems.size() - itemIndex - 1) * (getGap() + 1) + 1;
 
                 items = new GuiItem[Math.min(enabled, remainingPositions)];
             }
 
             for (int index = 0; index < items.length; index++) {
                 if (gapCount == 0) {
-                    items[index] = getItems().get(itemIndex);
+                    items[index] = allItems.get(itemIndex);
 
                     itemIndex++;
 
-                    if (doesRepeat() && itemIndex >= getItems().size()) {
+                    if (doesRepeat() && itemIndex >= allItems.size()) {
                         itemIndex = 0;
                     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/PaginatedPane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/PaginatedPane.java
@@ -9,6 +9,7 @@ import com.github.stefvanschie.inventoryframework.pane.util.PositionedPane;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -309,7 +310,7 @@ public class PaginatedPane extends Pane {
             return false;
         }
 
-		callOnClick(event);
+		callOnClick(new GuiClickEvent(event, slot));
 
         boolean success = false;
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/PaginatedPane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/PaginatedPane.java
@@ -406,7 +406,7 @@ public class PaginatedPane extends Pane {
     @NotNull
     @Contract(pure = true)
     public Collection<Pane> getPanes(int page) {
-        if (page < 0 || this.page >= this.panes.size()) {
+        if (page < 0 || page >= this.panes.size()) {
             throw new IllegalArgumentException("Invalid page");
         }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
@@ -10,6 +10,7 @@ import com.github.stefvanschie.inventoryframework.pane.util.Slot;
 import com.github.stefvanschie.inventoryframework.util.InventoryViewUtil;
 import com.github.stefvanschie.inventoryframework.util.UUIDTagType;
 import com.github.stefvanschie.inventoryframework.util.XMLUtil;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -49,7 +50,7 @@ public abstract class Pane {
      * The consumer that will be called once a players clicks in this pane
      */
     @Nullable
-    protected Consumer<? super InventoryClickEvent> onClick;
+    protected Consumer<? super GuiClickEvent> onClick;
 
     /**
      * A unique identifier for panes to locate them by
@@ -225,8 +226,10 @@ public abstract class Pane {
         if (element.hasAttribute("field"))
             XMLUtil.loadFieldAttribute(instance, element, pane);
 
-        if (element.hasAttribute("onClick"))
-            pane.setOnClick(XMLUtil.loadOnEventAttribute(instance, element, InventoryClickEvent.class, "onClick"));
+        if (element.hasAttribute("onClick")) {
+            Consumer<InventoryClickEvent> rawOnClick = XMLUtil.loadOnEventAttribute(instance, element, InventoryClickEvent.class, "onClick");
+            pane.setOnClick(rawOnClick == null ? null : e -> rawOnClick.accept(e.getClickEvent()));
+        }
 
         if (element.hasAttribute("populate")) {
             String attribute = element.getAttribute("populate");
@@ -346,7 +349,7 @@ public abstract class Pane {
      * @param onClick the consumer that gets called
      * @since 0.4.0
      */
-    public void setOnClick(@Nullable Consumer<? super InventoryClickEvent> onClick) {
+    public void setOnClick(@Nullable Consumer<? super GuiClickEvent> onClick) {
         this.onClick = onClick;
     }
     
@@ -357,19 +360,19 @@ public abstract class Pane {
      * @param event the event to handle
      * @since 0.6.0
      */
-    protected void callOnClick(@NotNull InventoryClickEvent event) {
+    protected void callOnClick(@NotNull GuiClickEvent event) {
         if (onClick == null) {
             return;
         }
-
 
         try {
             onClick.accept(event);
         } catch (Throwable t) {
             throw new RuntimeException(
                     "Exception while handling click event in inventory '"
-                    + InventoryViewUtil.getInstance().getTitle(event.getView()) + "', slot=" + event.getSlot() +
-                    ", for " + getClass().getSimpleName() + ", length=" + length + ", height=" + height,
+                    + InventoryViewUtil.getInstance().getTitle(event.getClickEvent().getView()) + "', slot="
+                    + event.getClickEvent().getSlot() + ", for " + getClass().getSimpleName() + ", length=" + length
+                    + ", height=" + height,
                     t
             );
         }

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/Pane.java
@@ -227,8 +227,7 @@ public abstract class Pane {
             XMLUtil.loadFieldAttribute(instance, element, pane);
 
         if (element.hasAttribute("onClick")) {
-            Consumer<InventoryClickEvent> rawOnClick = XMLUtil.loadOnEventAttribute(instance, element, InventoryClickEvent.class, "onClick");
-            pane.setOnClick(rawOnClick == null ? null : e -> rawOnClick.accept(e.getClickEvent()));
+            pane.setOnClick(XMLUtil.loadOnEventAttribute(instance, element, GuiClickEvent.class, "onClick"));
         }
 
         if (element.hasAttribute("populate")) {

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/PatternPane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/PatternPane.java
@@ -12,7 +12,9 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -133,7 +135,7 @@ public class PatternPane extends Pane implements Flippable, Rotatable {
             return false;
         }
 
-        callOnClick(event);
+        callOnClick(new GuiClickEvent(event, slot));
 
         ItemStack itemStack = event.getCurrentItem();
 
@@ -147,7 +149,7 @@ public class PatternPane extends Pane implements Flippable, Rotatable {
             return false;
         }
 
-        clickedItem.callAction(event);
+        clickedItem.callAction(new GuiClickEvent(event, slot));
 
         return true;
     }
@@ -204,6 +206,19 @@ public class PatternPane extends Pane implements Flippable, Rotatable {
         }
 
         return Collections.unmodifiableCollection(items);
+    }
+
+    @Nullable
+    @Contract(pure = true)
+    public GuiItem getGuiItem(@NotNull Slot slot) {
+        int x = slot.getX(getLength());
+        int y = slot.getY(getLength());
+
+        if (x < 0 || x >= getLength() || y < 0 || y >= getHeight()) {
+            return null;
+        }
+
+        return display().getItem(x, y);
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/StaticPane.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/StaticPane.java
@@ -7,6 +7,7 @@ import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.pane.util.GuiItemContainer;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
 import com.github.stefvanschie.inventoryframework.util.GeometryUtil;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
@@ -180,7 +181,7 @@ public class StaticPane extends Pane implements Flippable, Rotatable {
             return false;
         }
 
-		callOnClick(event);
+		callOnClick(new GuiClickEvent(event, slot));
 
         ItemStack itemStack = event.getCurrentItem();
 
@@ -194,7 +195,7 @@ public class StaticPane extends Pane implements Flippable, Rotatable {
             return false;
         }
 
-        clickedItem.callAction(event);
+        clickedItem.callAction(new GuiClickEvent(event, slot));
 
         return true;
 	}
@@ -242,7 +243,7 @@ public class StaticPane extends Pane implements Flippable, Rotatable {
      * @see #fillWith(ItemStack, Consumer)
      * @since 0.10.8
 	 */
-	public void fillWith(@NotNull ItemStack itemStack, @Nullable Consumer<? super InventoryClickEvent> action,
+	public void fillWith(@NotNull ItemStack itemStack, @Nullable Consumer<? super GuiClickEvent> action,
                          @NotNull Plugin plugin) {
 		//The non empty spots
 		Set<Slot> locations = this.items.keySet();
@@ -272,7 +273,7 @@ public class StaticPane extends Pane implements Flippable, Rotatable {
      * @param action The action called whenever an interaction with the item happens
      * @since 0.5.9
      */
-    public void fillWith(@NotNull ItemStack itemStack, @Nullable Consumer<? super InventoryClickEvent> action) {
+    public void fillWith(@NotNull ItemStack itemStack, @Nullable Consumer<? super GuiClickEvent> action) {
         fillWith(itemStack, action, JavaPlugin.getProvidingPlugin(StaticPane.class));
     }
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/CycleButton.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/CycleButton.java
@@ -7,6 +7,7 @@ import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
 import com.github.stefvanschie.inventoryframework.pane.util.GuiItemContainer;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
@@ -77,7 +78,7 @@ public class CycleButton extends Pane {
             position = 0;
         }
 
-        callOnClick(event);
+        callOnClick(new GuiClickEvent(event, slot));
 
         //use the previous position, since that will have the pane we clicked on
         panes.get(previousPosition).click(gui, guiComponent, event, slot);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PagingButtons.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PagingButtons.java
@@ -9,6 +9,7 @@ import com.github.stefvanschie.inventoryframework.pane.Pane;
 import com.github.stefvanschie.inventoryframework.pane.util.GuiItemContainer;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
 import org.bukkit.Material;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
@@ -143,7 +144,7 @@ public class PagingButtons extends Pane {
             return false;
         }
 
-        callOnClick(event);
+        callOnClick(new GuiClickEvent(event, slot));
 
         ItemStack itemStack = event.getCurrentItem();
 
@@ -155,7 +156,7 @@ public class PagingButtons extends Pane {
             try {
                 this.pages.setPage(this.pages.getPage() - 1);
 
-                this.backwardButton.callAction(event);
+                this.backwardButton.callAction(new GuiClickEvent(event, slot));
 
                 gui.update();
             } catch (ArrayIndexOutOfBoundsException ignored) {}
@@ -167,7 +168,7 @@ public class PagingButtons extends Pane {
             try {
                 this.pages.setPage(this.pages.getPage() + 1);
 
-                this.forwardButton.callAction(event);
+                this.forwardButton.callAction(new GuiClickEvent(event, slot));
 
                 gui.update();
             } catch (ArrayIndexOutOfBoundsException ignored) {}

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PercentageBar.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/PercentageBar.java
@@ -8,6 +8,7 @@ import com.github.stefvanschie.inventoryframework.pane.Orientable;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
 import com.github.stefvanschie.inventoryframework.pane.component.util.VariableBar;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
@@ -79,7 +80,7 @@ public class PercentageBar extends VariableBar {
             return false;
         }
 
-        callOnClick(event);
+        callOnClick(new GuiClickEvent(event, slot));
 
         event.setCancelled(true);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/Slider.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/Slider.java
@@ -8,6 +8,7 @@ import com.github.stefvanschie.inventoryframework.pane.Orientable;
 import com.github.stefvanschie.inventoryframework.pane.Pane;
 import com.github.stefvanschie.inventoryframework.pane.component.util.VariableBar;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
@@ -87,7 +88,7 @@ public class Slider extends VariableBar {
             throw new UnsupportedOperationException("Unknown orientation");
         }
 
-        callOnClick(event);
+        callOnClick(new GuiClickEvent(event, slot));
 
         boolean success = this.fillPane.click(gui, guiComponent, event, slot);
 

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/ToggleButton.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/ToggleButton.java
@@ -9,6 +9,7 @@ import com.github.stefvanschie.inventoryframework.pane.Pane;
 import com.github.stefvanschie.inventoryframework.pane.util.GuiItemContainer;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
 import org.bukkit.Material;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
@@ -178,7 +179,7 @@ public class ToggleButton extends Pane {
             toggle();
         }
 
-        callOnClick(event);
+        callOnClick(new GuiClickEvent(event, slot));
 
         /*
         Since we've toggled before, the click for the panes should be swapped around. If we haven't toggled due to

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/util/VariableBar.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/component/util/VariableBar.java
@@ -9,6 +9,7 @@ import com.github.stefvanschie.inventoryframework.pane.util.GuiItemContainer;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+import com.github.stefvanschie.inventoryframework.gui.GuiClickEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
@@ -77,9 +78,9 @@ public abstract class VariableBar extends Pane implements Orientable, Flippable 
         this.backgroundPane = new OutlinePane(length, height);
 
         this.fillPane.addItem(new GuiItem(new ItemStack(Material.GREEN_STAINED_GLASS_PANE),
-                event -> event.setCancelled(true), plugin));
+                event -> event.getClickEvent().setCancelled(true), plugin));
         this.backgroundPane.addItem(new GuiItem(new ItemStack(Material.RED_STAINED_GLASS_PANE),
-                event -> event.setCancelled(true), plugin));
+                event -> event.getClickEvent().setCancelled(true), plugin));
 
         this.fillPane.setRepeat(true);
         this.backgroundPane.setRepeat(true);

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/util/GuiItemContainer.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/pane/util/GuiItemContainer.java
@@ -146,10 +146,9 @@ public class GuiItemContainer {
                     "; should be below " + getLength() + " and " + getHeight());
         }
 
-        GuiItem copy = guiItem.copy();
-        copy.applyUUID();
+        guiItem.applyUUID();
 
-        this.items[x][y] = copy;
+        this.items[x][y] = guiItem;
     }
 
     /**

--- a/IF/src/main/java/com/github/stefvanschie/inventoryframework/util/XMLUtil.java
+++ b/IF/src/main/java/com/github/stefvanschie/inventoryframework/util/XMLUtil.java
@@ -2,7 +2,6 @@ package com.github.stefvanschie.inventoryframework.util;
 
 import com.github.stefvanschie.inventoryframework.exception.XMLLoadException;
 import com.github.stefvanschie.inventoryframework.exception.XMLReflectionException;
-import org.bukkit.event.Event;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,8 +26,8 @@ public class XMLUtil {
      */
     @Nullable
     @Contract(pure = true)
-    public static <T extends Event> Consumer<T> loadOnEventAttribute(@NotNull Object instance, @NotNull Element element,
-                                                                     @NotNull Class<T> eventType, @NotNull String name) {
+    public static <T> Consumer<T> loadOnEventAttribute(@NotNull Object instance, @NotNull Element element,
+                                                       @NotNull Class<T> eventType, @NotNull String name) {
         String attribute = element.getAttribute(name);
         for (Method method : instance.getClass().getMethods()) {
             if (!method.getName().equals(attribute))


### PR DESCRIPTION
Wrap InventoryClickEvent in GuiClickEvent for pane-level click handlers

Introduce GuiClickEvent, which wraps a Bukkit InventoryClickEvent together
with a pane-relative Slot, so click consumers always receive the slot
position expressed relative to the pane's top-left corner rather than the
raw inventory index.

GuiItem.action and Pane.onClick are now Consumer<? super GuiClickEvent>.
All pane click() implementations construct a GuiClickEvent(event, slot)
before forwarding to callOnClick/callAction. XML-loaded handlers that still
declare an InventoryClickEvent parameter continue to work via an automatic
unwrapping wrapper. Gui-level consumers (onTopClick, onBottomClick, etc.)
are unaffected as they have no pane-relative context.