### PR TITLE
Fix IllegalAccessError in AnvilInventoryImpl

### DIFF
--- a/nms/26_1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v26_1/AnvilInventoryImpl.java
+++ b/nms/26_1/src/main/java/com/github/stefvanschie/inventoryframework/nms/v26_1/AnvilInventoryImpl.java
@@ -220,7 +220,7 @@ public class AnvilInventoryImpl extends AnvilInventory {
         private void updateSlot(int slotIndex, @NotNull Container container) {
             Slot slot = super.slots.get(slotIndex);
 
-            Slot newSlot = new Slot(container, slot.slot, slot.x, slot.y);
+            Slot newSlot = new Slot(container, slot.getContainerSlot(), slot.x, slot.y);
             newSlot.index = slot.index;
 
             super.slots.set(slotIndex, newSlot);


### PR DESCRIPTION
On paper minecraft 26.2 I was getting following error when trying to open an anvil GUI:
```
java.lang.IllegalAccessError: class com.github.stefvanschie.inventoryframework.nms.v26_1.AnvilInventoryImpl$ContainerAnvilImpl tried to access private field net.minecraft.world.inventory.Slot.slot (com.github.stefvanschie.inventoryframework.nms.v26_1.AnvilInventoryImpl$ContainerAnvilImpl is in unnamed module of loader 'WaystoneWarps-1.1.0-SNAPSHOT.jar' @5e9ada49; net.minecraft.world.inventory.Slot is in unnamed module of loader java.net.URLClassLoader @433c675d)
   at WaystoneWarps-1.1.0-SNAPSHOT.jar//com.github.stefvanschie.inventoryframework.nms.v26_1.AnvilInventoryImpl$ContainerAnvilImpl.updateSlot(AnvilInventoryImpl.java:223) ~[?:?]
   at WaystoneWarps-1.1.0-SNAPSHOT.jar//com.github.stefvanschie.inventoryframework.nms.v26_1.AnvilInventoryImpl$ContainerAnvilImpl.<init>(AnvilInventoryImpl.java:134) ~[?:?]
   at WaystoneWarps-1.1.0-SNAPSHOT.jar//com.github.stefvanschie.inventoryframework.nms.v26_1.AnvilInventoryImpl$1$1.createMenu(AnvilInventoryImpl.java:60) ~[?:?]
```

This fixes the issue by using the appropriate [public function](https://aldak0.ru/javadoc/26.1.x/net/minecraft/world/inventory/Slot.html#getContainerSlot()).